### PR TITLE
(Bugfix): vscextension on MacOS

### DIFF
--- a/docs/vscode-extension.md
+++ b/docs/vscode-extension.md
@@ -49,8 +49,8 @@ All settings live under `Context Engine Uploader` in the VS Code settings UI or 
 | `contextEngineUploader.decoderUrl` | Override `DECODER_URL` passed into `scripts/ctx.py` when running Prompt+. Defaults to local llama.cpp (`http://localhost:8081`, auto-appends `/completion`). Use `http://localhost:11434/api/chat` for Ollama. |
 | `contextEngineUploader.useGlmDecoder` | Set `REFRAG_RUNTIME=glm` for Prompt+ to hit GLM instead of Ollama/llama.cpp. |
 | `contextEngineUploader.useGpuDecoder` | Set `USE_GPU_DECODER=1` so ctx.py prefers the GPU llama.cpp sidecar. |
-| `contextEngineUploader.targetPath` | Absolute path that should be passed to `--path` (for example `/Users/mikah/Nadi/dumon/dumon-ai-engine-revised`). |
-| `contextEngineUploader.endpoint` | Remote endpoint passed to `--endpoint`, defaulting to `http://mcp.speramus.id:8004`. |
+| `contextEngineUploader.targetPath` | Absolute path that should be passed to `--path` (for example `/users/mycode`). |
+| `contextEngineUploader.endpoint` | Remote endpoint passed to `--endpoint`, defaulting to `http://localhost:8004`. |
 | `contextEngineUploader.intervalSeconds` | Poll interval for watch mode. Set to `5` to match the previous command file. |
 | `contextEngineUploader.extraForceArgs` | Optional string array appended to the force invocation. Leave empty for the standard workflow. |
 | `contextEngineUploader.extraWatchArgs` | Optional string array appended to the watch invocation. |

--- a/vscode-extension/build/build.sh
+++ b/vscode-extension/build/build.sh
@@ -37,7 +37,13 @@ chmod +x "$STAGE_DIR/$CLIENT"
 # Optional: bundle Python deps into the staged extension when requested
 if [[ "$BUNDLE_DEPS" == "--bundle-deps" ]]; then
     echo "Bundling Python dependencies into staged extension using $PYTHON_BIN..."
-    "$PYTHON_BIN" -m pip install -t "$STAGE_DIR/python_libs" requests urllib3 charset_normalizer
+    # On macOS, urllib3 v2 + system LibreSSL emits NotOpenSSLWarning; pin <2 there.
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        echo "Detected macOS; pinning urllib3<2 to avoid LibreSSL/OpenSSL warning."
+        "$PYTHON_BIN" -m pip install -t "$STAGE_DIR/python_libs" "urllib3<2" requests charset_normalizer
+    else
+        "$PYTHON_BIN" -m pip install -t "$STAGE_DIR/python_libs" requests urllib3 charset_normalizer
+    fi
 fi
 
 pushd "$STAGE_DIR" >/dev/null

--- a/vscode-extension/context-engine-uploader/package.json
+++ b/vscode-extension/context-engine-uploader/package.json
@@ -2,7 +2,7 @@
   "name": "context-engine-uploader",
   "displayName": "Context Engine Uploader",
   "description": "Runs the Context-Engine remote upload client with a force sync on startup followed by watch mode. Requires Python with pip install requests urllib3 charset_normalizer.",
-  "version": "0.1.16",
+  "version": "0.1.25",
   "publisher": "context-engine",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
- Pin urllib3<2 on macOS to avoid LibreSSL warning
- configure PYTHONPATH for bundled deps check (bugfix on macOS) 
- update docs defaults