### PR TITLE
Deploys upload service and uses ClusterIP

### DIFF
--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
 
   # Optional services
   - llamacpp.yaml
+  - upload-service.yaml
   - ingress.yaml
 
 # Common labels

--- a/deploy/kubernetes/llamacpp.yaml
+++ b/deploy/kubernetes/llamacpp.yaml
@@ -146,12 +146,12 @@ metadata:
     app: context-engine
     component: llamacpp
 spec:
-  type: NodePort  # Change to LoadBalancer for external access
+  type: ClusterIP  # Change to LoadBalancer for external access
   ports:
   - name: http
     port: 8080
     targetPort: http
-    nodePort: 30808  # Optional: specify node port
+    # nodePort: 30808  # Optional: specify node port
     protocol: TCP
   selector:
     app: context-engine

--- a/deploy/kubernetes/mcp-http.yaml
+++ b/deploy/kubernetes/mcp-http.yaml
@@ -118,17 +118,15 @@ metadata:
     app: context-engine
     component: mcp-memory-http
 spec:
-  type: NodePort  # Change to LoadBalancer for external access
+  type: ClusterIP  # Change to LoadBalancer for external access
   ports:
   - name: http
     port: 8002
     targetPort: http
-    nodePort: 30804  # Optional: specify node port
     protocol: TCP
   - name: health
     port: 18002
     targetPort: health
-    nodePort: 30805  # Optional: specify node port
     protocol: TCP
   selector:
     app: context-engine
@@ -310,17 +308,15 @@ metadata:
     app: context-engine
     component: mcp-indexer-http
 spec:
-  type: NodePort  # Change to LoadBalancer for external access
+  type: ClusterIP  # Change to LoadBalancer for external access
   ports:
   - name: http
     port: 8003
     targetPort: http
-    nodePort: 30806  # Optional: specify node port
     protocol: TCP
   - name: health
     port: 18003
     targetPort: health
-    nodePort: 30807  # Optional: specify node port
     protocol: TCP
   selector:
     app: context-engine

--- a/deploy/kubernetes/mcp-indexer.yaml
+++ b/deploy/kubernetes/mcp-indexer.yaml
@@ -111,17 +111,15 @@ metadata:
     app: context-engine
     component: mcp-indexer
 spec:
-  type: NodePort  # Change to LoadBalancer for external access
+  type: ClusterIP  # Change to LoadBalancer for external access
   ports:
   - name: sse
     port: 8001
     targetPort: sse
-    nodePort: 30802  # Optional: specify node port
     protocol: TCP
   - name: health
     port: 18001
     targetPort: health
-    nodePort: 30803  # Optional: specify node port
     protocol: TCP
   selector:
     app: context-engine

--- a/deploy/kubernetes/mcp-memory.yaml
+++ b/deploy/kubernetes/mcp-memory.yaml
@@ -102,17 +102,15 @@ metadata:
     app: context-engine
     component: mcp-memory
 spec:
-  type: NodePort  # Change to LoadBalancer for external access
+  type: ClusterIP  # Change to LoadBalancer for external access
   ports:
   - name: sse
     port: 8000
     targetPort: sse
-    nodePort: 30800  # Optional: specify node port
     protocol: TCP
   - name: health
     port: 18000
     targetPort: health
-    nodePort: 30801  # Optional: specify node port
     protocol: TCP
   selector:
     app: context-engine

--- a/deploy/kubernetes/upload-service.yaml
+++ b/deploy/kubernetes/upload-service.yaml
@@ -122,7 +122,7 @@ spec:
   - name: http
     port: 8002
     targetPort: http
-    nodePort: 30804  # Optional: specify node port
+    nodePort: 30810  # Optional: specify node port
     protocol: TCP
   selector:
     app: context-engine


### PR DESCRIPTION
Adds the upload service to the kustomization file, enabling its deployment.

Configures all services to use ClusterIP instead of NodePort, restricting external access by default. NodePort is still configurable.