### PR TITLE
mcp_indexer_server: fix: make repo_search tolerant of mcp-remote args schema

### DIFF
--- a/scripts/mcp_indexer_server.py
+++ b/scripts/mcp_indexer_server.py
@@ -1695,6 +1695,7 @@ async def repo_search(
     case: Any = None,
     # Response shaping
     compact: Any = None,
+    args: Any = None,  # Compatibility shim for mcp-remote/Claude wrappers that send args/kwargs
     kwargs: Any = None,
 ) -> Dict[str, Any]:
     """Zero-config code search over repositories (hybrid: vector + lexical RRF, optional rerank).


### PR DESCRIPTION
The qdrant-indexer MCP server was emitting a flat schema for repo_search
(query, limit, include_snippet, collection, etc.), but the Windsurf/Claude
qdrant-indexer integration (via mcp-remote) was still modeling this tool as
taking {args, kwargs}. This mismatch surfaced as:

- Client: repo_searchArguments.args is required
- Server: repo_search() got an unexpected keyword argument 'args'

To make repo_search compatible with both direct FastMCP clients and the
mcp-remote wrapper, we:

- Added an optional args: Any = None parameter to repo_search, treated as
  a no-op "compatibility shim" for clients that insist on sending args/kwargs.
- Left all existing named parameters and kwargs handling unchanged so
  direct callers and internal wrappers keep working as before.



Net effect:
- repo_search now tolerates the mcp-remote/Claude {args, kwargs} calling
  convention without breaking direct FastMCP usage.