### PR TITLE
k8 manifests:Updates storage class names for Ceph

### DIFF
--- a/deploy/kubernetes/code-models-pvc.yaml
+++ b/deploy/kubernetes/code-models-pvc.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany  # CephFS supports RWX for multiple pods
-  storageClassName: rook-cephfs  # Adjust based on your storage class
+  storageClassName: ceph-filesystem  # Adjust based on your storage class
   resources:
     requests:
       storage: 20Gi  # Adjust size based on expected model footprint

--- a/deploy/kubernetes/qdrant.yaml
+++ b/deploy/kubernetes/qdrant.yaml
@@ -67,7 +67,7 @@ spec:
         component: qdrant
     spec:
       accessModes: ["ReadWriteOnce"]
-# storageClassName: "" # Uncomment and set if you want to specify a storage class
+      storageClassName: ceph-block  # Ceph RWO block storage
       resources:
         requests:
           storage: 20Gi

--- a/deploy/kubernetes/upload-codebase-pvc.yaml
+++ b/deploy/kubernetes/upload-codebase-pvc.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany  # CephFS supports RWX for multiple pods
-  storageClassName: rook-cephfs  # Adjust based on your CephFS storage class
+  storageClassName: ceph-filesystem  # Adjust based on your CephFS storage class
   resources:
     requests:
       storage: 5Gi  # Smaller size for metadata/cache

--- a/deploy/kubernetes/upload-pvc.yaml
+++ b/deploy/kubernetes/upload-pvc.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany  # CephFS supports RWX for multiple pods
-  storageClassName: rook-cephfs  # Adjust based on your CephFS storage class
+  storageClassName: ceph-filesystem  # Adjust based on your CephFS storage class
   resources:
     requests:
       storage: 10Gi  # Adjust size based on your needs
@@ -36,7 +36,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany  # CephFS supports RWX for multiple pods
-  storageClassName: rook-cephfs  # Adjust based on your CephFS storage class
+  storageClassName: ceph-filesystem  # Adjust based on your CephFS storage class
   resources:
     requests:
       storage: 5Gi  # Smaller size for metadata/cache


### PR DESCRIPTION
Updates the storage class names in the Kubernetes persistent volume claim (PVC) definitions to align with the Ceph storage configuration.

Specifically, it changes the `storageClassName` from `rook-cephfs` to `ceph-filesystem` for the shared filesystem and sets `ceph-block` for the qdrant block storage.