### PR TITLE
k8: Updates readiness and liveness probe settings

### DIFF
--- a/deploy/kubernetes/mcp-http.yaml
+++ b/deploy/kubernetes/mcp-http.yaml
@@ -273,14 +273,18 @@ spec:
           httpGet:
             path: /readyz
             port: health
-          initialDelaySeconds: 30
-          periodSeconds: 10
+          initialDelaySeconds: 120
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 6
         readinessProbe:
           httpGet:
             path: /readyz
             port: health
-          initialDelaySeconds: 10
-          periodSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 15
+          timeoutSeconds: 10
+          failureThreshold: 6
         envFrom:
         - configMapRef:
             name: context-engine-config

--- a/deploy/kubernetes/mcp-indexer.yaml
+++ b/deploy/kubernetes/mcp-indexer.yaml
@@ -79,14 +79,18 @@ spec:
           httpGet:
             path: /readyz
             port: health
-          initialDelaySeconds: 30
-          periodSeconds: 10
+          initialDelaySeconds: 120
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 6
         readinessProbe:
           httpGet:
             path: /readyz
             port: health
-          initialDelaySeconds: 10
-          periodSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 15
+          timeoutSeconds: 10
+          failureThreshold: 6
         envFrom:
         - configMapRef:
             name: context-engine-config


### PR DESCRIPTION
Improves the reliability of service startup by increasing the initial delay and period for readiness and liveness probes.

This change also adds timeout and failure threshold settings to prevent premature service termination.