### PR TITLE
k8:Adds security context and refactors storage

### DIFF
--- a/deploy/kubernetes/indexer-services.yaml
+++ b/deploy/kubernetes/indexer-services.yaml
@@ -19,6 +19,10 @@ spec:
         component: indexer-service
     spec:
       serviceAccountName: context-engine
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
       - name: watcher
         image: context-engine-indexer-service
@@ -109,6 +113,10 @@ spec:
         component: indexer
     spec:
       serviceAccountName: context-engine
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       restartPolicy: OnFailure
       containers:
       - name: indexer
@@ -173,6 +181,10 @@ spec:
         component: init
     spec:
       serviceAccountName: context-engine
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       restartPolicy: OnFailure
       containers:
       - name: init-payload

--- a/deploy/kubernetes/mcp-http.yaml
+++ b/deploy/kubernetes/mcp-http.yaml
@@ -19,6 +19,10 @@ spec:
         component: mcp-memory-http
     spec:
       serviceAccountName: context-engine
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
       - name: mcp-memory-http
         image: context-engine-memory
@@ -178,6 +182,10 @@ spec:
         component: mcp-indexer-http
     spec:
       serviceAccountName: context-engine
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
       - name: mcp-indexer-http
         image: context-engine-indexer

--- a/deploy/kubernetes/mcp-indexer.yaml
+++ b/deploy/kubernetes/mcp-indexer.yaml
@@ -19,6 +19,10 @@ spec:
         component: mcp-indexer
     spec:
       serviceAccountName: context-engine
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
       - name: mcp-indexer
         image: context-engine-indexer

--- a/deploy/kubernetes/upload-codebase-pvc.yaml
+++ b/deploy/kubernetes/upload-codebase-pvc.yaml
@@ -1,23 +1,7 @@
----
-# Persistent Volume Claim for codebase metadata storage (CephFS RWX)
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: upload-codebase-pvc
-  namespace: context-engine
-  labels:
-    app: context-engine
-    component: upload-service
-    type: storage
-spec:
-  accessModes:
-    - ReadWriteMany  # CephFS supports RWX for multiple pods
-  storageClassName: ceph-filesystem  # Adjust based on your CephFS storage class
-  resources:
-    requests:
-      storage: 5Gi  # Smaller size for metadata/cache
-  # Optional: selector for specific PV
-  # selector:
-  #   matchLabels:
-  #     app: context-engine
-  #     component: upload-codebase
+## Deprecated: upload-codebase-pvc
+##
+## This file previously defined a separate PVC for upload-service metadata.
+## The architecture now shares a single metadata volume (code-metadata-pvc)
+## across upload-service and indexers, so this PVC is intentionally removed.
+##
+## Left as a stub to avoid accidental kubectl apply of an unused resource.

--- a/deploy/kubernetes/upload-service.yaml
+++ b/deploy/kubernetes/upload-service.yaml
@@ -107,7 +107,7 @@ spec:
           claimName: code-repos-pvc
       - name: codebase-volume
         persistentVolumeClaim:
-          claimName: upload-codebase-pvc
+          claimName: code-metadata-pvc
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Adds securityContext to several deployments to ensure consistent user and group IDs for container execution.

Refactors storage by removing the dedicated
upload-codebase-pvc and switching upload-service to use the shared code-metadata-pvc. This simplifies the storage architecture and allows upload-service and indexers to share a single metadata volume.