### PR TITLE
Update hybrid_search.py

### DIFF
--- a/.env
+++ b/.env
@@ -29,9 +29,9 @@ TOOL_FIND_DESCRIPTION="Search for relevant code snippets using multiple phrasing
 
 
 # Optional: local cross-encoder reranker (ONNX)
-# Set these to enable make rerank-local inside the container
-RERANKER_ONNX_PATH=/work/models/model_qint8_avx512_vnni.onnx
-RERANKER_TOKENIZER_PATH=/work/models/tokenizer.json
+# Baked into Docker image at /app/models/ - no host mount needed
+RERANKER_ONNX_PATH=/app/models/reranker.onnx
+RERANKER_TOKENIZER_PATH=/app/models/tokenizer.json
 
 # Reranker toggles and tuning
 # Increased TOPN and RETURN_M for better final ranking

--- a/Dockerfile.mcp-indexer
+++ b/Dockerfile.mcp-indexer
@@ -6,13 +6,25 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     WORK_ROOTS="/work,/app"
 
-# OS deps (git for history if we extend later)
-RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+# OS deps (git for history if we extend later, curl for model downloads)
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Python deps: reuse shared requirements (includes FastMCP + OpenAI SDK)
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /tmp/requirements.txt
+
+# Download reranker model and tokenizer during build
+# Cross-encoder for reranking (ms-marco-MiniLM) + BGE tokenizer for micro-chunking
+ARG RERANKER_ONNX_URL=https://huggingface.co/cross-encoder/ms-marco-MiniLM-L-6-v2/resolve/main/onnx/model.onnx
+ARG TOKENIZER_URL=https://huggingface.co/BAAI/bge-base-en-v1.5/resolve/main/tokenizer.json
+RUN mkdir -p /app/models && \
+    curl -L --fail --retry 3 -o /app/models/reranker.onnx "${RERANKER_ONNX_URL}" && \
+    curl -L --fail --retry 3 -o /app/models/tokenizer.json "${TOKENIZER_URL}"
+
+# Set default paths for reranker (can be overridden via env)
+ENV RERANKER_ONNX_PATH=/app/models/reranker.onnx \
+    RERANKER_TOKENIZER_PATH=/app/models/tokenizer.json
 
 # Bake scripts into the image so entrypoints don't rely on /work
 COPY scripts /app/scripts


### PR DESCRIPTION
feat(hybrid-search): auto-scale search parameters for large codebases

Automatically adjust RRF and retrieval parameters based on collection size to maintain search quality at scale (100k-500k+ LOC codebases).

Changes:
- Add _scale_rrf_k(): logarithmic RRF k scaling for better score discrimination
- Add _adaptive_per_query(): sqrt-based candidate retrieval scaling
- Add _normalize_scores(): z-score + sigmoid normalization for compressed distributions
- Add _get_collection_stats(): cached collection size lookup (5-min TTL)
- Apply scaling to both MCP (run_hybrid_search) and CLI paths
- All scaling enabled by default, no configuration required

Scaling behavior:
- Threshold: 10,000 points (configurable via HYBRID_LARGE_THRESHOLD)
- RRF k: 60 → up to 180 (3x max, logarithmic)
- Per-query: 24 → up to 72 (3x max, sqrt scaling)
- Score normalization spreads compressed score ranges

Small codebases (<10k points) are unaffected - parameters unchanged.

=== Large Codebase Scaling Tests ===
LARGE_COLLECTION_THRESHOLD: 10000
MAX_RRF_K_SCALE: 3.0
SCORE_NORMALIZE_ENABLED: True
Base RRF_K: 60

--- RRF K Scaling ---
     5000 points -> k=60
    10000 points -> k=60
    50000 points -> k=101
   100000 points -> k=120
   250000 points -> k=143
   500000 points -> k=161

--- Per-Query Scaling ---
     5000 points -> per_query=24 (filtered=24)
    10000 points -> per_query=24 (filtered=24)
    50000 points -> per_query=53 (filtered=37)
   100000 points -> per_query=72 (filtered=53)
   250000 points -> per_query=72 (filtered=72)
   500000 points -> per_query=72 (filtered=72)

--- Score Normalization ---
  Before (compressed): [0.5, 0.505, 0.51, 0.495]
  After (spread):      [0.4443, 0.5557, 0.6617, 0.3383]
  Range: 0.4950-0.5100 -> 0.3383-0.6617

-------------------
Collection: codebase
Points: 16622
Threshold: 10000
Scaling Active: True

RRF K: 60 -> 73 (scale factor: 1.22x)
Per-query: 24 -> 30 (no filters)
Per-query: 24 -> 24 (with filters)