### PR TITLE
Add MiniMax M2 decoder backend support

### DIFF
--- a/.env
+++ b/.env
@@ -129,7 +129,7 @@ REFRAG_ENCODER_MODEL=BAAI/bge-base-en-v1.5
 REFRAG_PHI_PATH=/work/models/refrag_phi_768_to_dmodel.bin
 REFRAG_SENSE=heuristic
 REFRAG_PSEUDO_DESCRIBE=1
-GLM_API_KEY=
+
 # Llama.cpp sidecar (optional)
 # Use docker network hostname from containers; localhost remains ok for host-side runs if LLAMACPP_URL not exported
 LLAMACPP_URL=http://host.docker.internal:8081
@@ -200,8 +200,16 @@ INFO_REQUEST_LIMIT=10
 INFO_REQUEST_CONTEXT_LINES=5
 # INFO_REQUEST_EXPLAIN_DEFAULT=0
 # INFO_REQUEST_RELATIONSHIPS=0
+# GLM (ZhipuAI) decoder backend
+GLM_API_KEY=
 GLM_API_BASE=https://api.z.ai/api/coding/paas/v4/
 GLM_MODEL=glm-4.6
+
+# MiniMax M2 decoder backend
+MINIMAX_API_KEY=
+MINIMAX_API_BASE=https://api.minimax.io/v1
+MINIMAX_MODEL=MiniMax-M2
+
 COMMIT_VECTOR_SEARCH=0
 STRICT_MEMORY_RESTORE=1
 CTXCE_AUTH_ENABLED=0

--- a/.env.example
+++ b/.env.example
@@ -160,9 +160,15 @@ REFRAG_PSEUDO_DESCRIBE=1
 LLAMACPP_URL=http://llamacpp:8080
 REFRAG_DECODER_MODE=prompt  # prompt|soft
 
+# GLM (ZhipuAI) decoder backend
 # GLM_API_BASE=https://api.z.ai/api/coding/paas/v4/
 # GLM_MODEL=glm-4.6
 # GLM_API_KEY=your_glm_api_key_here
+
+# MiniMax M2 decoder backend (OpenAI-compatible API)
+# MINIMAX_API_BASE=https://api.minimax.io/v1
+# MINIMAX_MODEL=MiniMax-M2
+# MINIMAX_API_KEY=your_minimax_api_key_here
 
 # GPU Performance Toggle
 # Set to 1 to use native GPU-accelerated server on localhost:8081

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -12,7 +12,7 @@ Complete environment variable reference for Context Engine.
 - [Query Optimization](#query-optimization)
 - [Watcher Settings](#watcher-settings)
 - [Reranker](#reranker)
-- [Decoder (llama.cpp / GLM)](#decoder-llamacpp--glm)
+- [Decoder (llama.cpp / GLM / MiniMax)](#decoder-llamacpp--glm--minimax)
 - [ReFRAG](#refrag)
 - [Ports](#ports)
 - [Search & Expansion](#search--expansion)
@@ -83,18 +83,23 @@ Dynamic HNSW_EF tuning and intelligent query routing for 2x faster simple querie
 | RERANKER_TOKENIZER_PATH | Tokenizer path for reranker | unset |
 | RERANKER_ENABLED | Enable reranker by default | 1 (enabled) |
 
-## Decoder (llama.cpp / GLM)
+## Decoder (llama.cpp / GLM / MiniMax)
 
 | Name | Description | Default |
 |------|-------------|---------|
 | REFRAG_DECODER | Enable decoder for context_answer | 1 (enabled) |
-| REFRAG_RUNTIME | Decoder backend: llamacpp or glm | llamacpp |
+| REFRAG_RUNTIME | Decoder backend: llamacpp, glm, or minimax | llamacpp |
 | LLAMACPP_URL | llama.cpp server endpoint | http://llamacpp:8080 or http://host.docker.internal:8081 |
 | LLAMACPP_TIMEOUT_SEC | Decoder request timeout | 300 |
 | DECODER_MAX_TOKENS | Max tokens for decoder responses | 4000 |
 | REFRAG_DECODER_MODE | prompt or soft (soft requires patched llama.cpp) | prompt |
 | GLM_API_KEY | API key for GLM provider | unset |
 | GLM_MODEL | GLM model name | glm-4.6 |
+| GLM_TIMEOUT_SEC | GLM request timeout in seconds | unset |
+| MINIMAX_API_KEY | API key for MiniMax M2 provider | unset |
+| MINIMAX_MODEL | MiniMax model name | MiniMax-M2 |
+| MINIMAX_API_BASE | MiniMax API base URL | https://api.minimax.io/v1 |
+| MINIMAX_TIMEOUT_SEC | MiniMax request timeout in seconds | unset |
 | USE_GPU_DECODER | Native Metal decoder (1) vs Docker (0) | 0 (docker) |
 | LLAMACPP_GPU_LAYERS | Number of layers to offload to GPU, -1 for all | 32 |
 

--- a/scripts/mcp_indexer_server.py
+++ b/scripts/mcp_indexer_server.py
@@ -6787,6 +6787,10 @@ def _ca_decode(
         from scripts.refrag_glm import GLMRefragClient  # type: ignore
 
         client = GLMRefragClient()
+    elif runtime_kind == "minimax":
+        from scripts.refrag_minimax import MiniMaxRefragClient  # type: ignore
+
+        client = MiniMaxRefragClient()
     else:
         from scripts.refrag_llamacpp import LlamaCppRefragClient  # type: ignore
 
@@ -6806,7 +6810,7 @@ def _ca_decode(
                 "top_p": top_p,
                 "stop": stops,
             }
-            if runtime_kind == "glm":
+            if runtime_kind in ("glm", "minimax"):
                 timeout_value: Optional[float] = None
                 if timeout is not None:
                     try:
@@ -6814,7 +6818,9 @@ def _ca_decode(
                     except Exception:
                         timeout_value = None
                 if timeout_value is None:
-                    raw_timeout = os.environ.get("GLM_TIMEOUT_SEC", "").strip()
+                    # Check runtime-specific timeout env var, then fall back to generic
+                    env_key = "MINIMAX_TIMEOUT_SEC" if runtime_kind == "minimax" else "GLM_TIMEOUT_SEC"
+                    raw_timeout = os.environ.get(env_key, "").strip()
                     if raw_timeout:
                         try:
                             timeout_value = float(raw_timeout)

--- a/scripts/refrag_minimax.py
+++ b/scripts/refrag_minimax.py
@@ -1,0 +1,92 @@
+"""
+Feature-flagged adapter for decoder-side ReFRAG using MiniMax M2.
+
+Safe defaults:
+- Only used when REFRAG_DECODER=1 and REFRAG_RUNTIME=minimax
+- Requires MINIMAX_API_KEY; optionally configure MINIMAX_MODEL
+
+MiniMax M2 API is OpenAI-compatible at https://api.minimax.io/v1
+"""
+from __future__ import annotations
+import os
+from typing import Any, Optional
+
+
+class MiniMaxRefragClient:
+    """MiniMax M2 client exposing generate_with_soft_embeddings(prompt, ...).
+
+    Notes:
+    - soft_embeddings are ignored (MiniMax does not support KV/soft-embed injection)
+    - prompt-mode only; mirrors llama.cpp adapter surface
+    - Uses OpenAI SDK with custom base_url for MiniMax API
+    """
+
+    def __init__(self, api_key: Optional[str] = None, base_url: Optional[str] = None) -> None:
+        self.api_key = api_key or os.environ.get("MINIMAX_API_KEY", "").strip()
+        if not self.api_key:
+            raise ValueError("MINIMAX_API_KEY is required when using REFRAG_RUNTIME=minimax")
+        self.base_url = base_url or os.environ.get("MINIMAX_API_BASE", "https://api.minimax.io/v1")
+        from openai import OpenAI
+        self.client = OpenAI(api_key=self.api_key, base_url=self.base_url)
+
+    def generate_with_soft_embeddings(
+        self,
+        prompt: str,
+        soft_embeddings: Optional[list[list[float]]] = None,  # unused
+        max_tokens: Optional[int] = None,
+        **gen_kwargs: Any,
+    ) -> str:
+        model = os.environ.get("MINIMAX_MODEL", "MiniMax-M2")
+        # Use DECODER_MAX_TOKENS env var; no hardcoded cap (MiniMax uses thinking tokens)
+        if max_tokens is None:
+            try:
+                max_tokens = int(os.environ.get("DECODER_MAX_TOKENS", "4096"))
+            except ValueError:
+                max_tokens = 4096
+        temperature = float(gen_kwargs.get("temperature", 0.2))
+        top_p = float(gen_kwargs.get("top_p", 0.95))
+        stop = gen_kwargs.get("stop")
+        timeout = gen_kwargs.pop("timeout", None)
+        # Optional hint from callers that they want strict JSON output.
+        force_json = bool(gen_kwargs.pop("force_json", False))
+        try:
+            timeout_val = float(timeout) if timeout is not None else None
+        except Exception:
+            timeout_val = None
+
+        try:
+            # Prefer explicit gen_kwargs override, else use computed max_tokens
+            final_max_tokens = int(gen_kwargs.get("max_tokens", max_tokens))
+            create_kwargs: dict[str, Any] = {
+                "model": model,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": final_max_tokens,
+                "temperature": temperature,
+                "top_p": top_p,
+                "stop": stop if stop else None,
+                "timeout": timeout_val,
+            }
+            # When explicitly requested and supported by the backend, ask for
+            # JSON-only responses. If the provider rejects this parameter, the
+            # API call will raise and the caller will handle the failure.
+            if force_json:
+                create_kwargs["response_format"] = {"type": "json_object"}
+
+            response = self.client.chat.completions.create(**create_kwargs)
+            msg = response.choices[0].message
+            content = msg.content or ""
+            # MiniMax M2 may return <think>...</think> reasoning tokens; strip them
+            content = self._strip_thinking_tokens(content)
+            return content.strip()
+        except Exception as e:
+            raise RuntimeError(f"MiniMax completion failed: {e}")
+
+    def _strip_thinking_tokens(self, text: str) -> str:
+        """Remove <think>...</think> blocks from MiniMax M2 responses."""
+        import re
+        # Remove <think>...</think> blocks (including partial/truncated ones)
+        text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL)
+        # Also handle unclosed <think> tags (truncated responses)
+        text = re.sub(r"<think>.*$", "", text, flags=re.DOTALL)
+        return text.strip()
+


### PR DESCRIPTION
Introduces support for the MiniMax M2 decoder backend, including environment variable configuration, documentation updates, and a new adapter (scripts/refrag_minimax.py). The mcp_indexer_server.py logic is updated to route decoding requests to MiniMax when REFRAG_RUNTIME is set to 'minimax', and timeout handling is extended to support MiniMax-specific settings.