### PR TITLE
fix(indexer): exclude nested .remote-git dirs during /work multi-repo…

### DIFF
--- a/scripts/ingest_code.py
+++ b/scripts/ingest_code.py
@@ -346,6 +346,13 @@ _DEFAULT_EXCLUDE_FILES = [
     "*.tar.gz",
 ]
 
+_ANY_DEPTH_EXCLUDE_DIR_NAMES = {
+    ".git",
+    ".remote-git",
+    ".codebase",
+    "node_modules",
+}
+
 def _should_skip_explicit_file_by_excluder(file_path: Path) -> bool:
     try:
         p = file_path if isinstance(file_path, Path) else Path(str(file_path))
@@ -477,16 +484,8 @@ class _Excluder:
         # "exclude this directory name anywhere". This matters when indexing a
         # workspace root that contains multiple repos, e.g. /work/<repo>/.git.
         try:
-            for pref in self.dir_prefixes:
-                if not str(pref or "").startswith("/"):
-                    continue
-                seg = str(pref or "").strip("/")
-                if not seg or "/" in seg:
-                    continue
-                if not (seg.startswith(".") or seg == "node_modules"):
-                    continue
-                if base == seg:
-                    return True
+            if base in _ANY_DEPTH_EXCLUDE_DIR_NAMES and ("/" + base) in self.dir_prefixes:
+                return True
         except Exception:
             pass
 

--- a/tests/test_ingest_excluder.py
+++ b/tests/test_ingest_excluder.py
@@ -9,6 +9,7 @@ def test_excluder_defaults_and_ignore(tmp_path, monkeypatch):
     # Create files and dirs
     (root / ".git").mkdir()
     (root / "node_modules").mkdir()
+    (root / ".remote-git").mkdir()
     (root / "keep.py").write_text("print('ok')\n")
     (root / "skip.log").write_text("log\n")
 
@@ -19,6 +20,7 @@ def test_excluder_defaults_and_ignore(tmp_path, monkeypatch):
     # Defaults should exclude .git and node_modules directories
     assert excl.exclude_dir("/.git")
     assert excl.exclude_dir("/node_modules")
+    assert excl.exclude_dir("/.remote-git")
     # .qdrantignore should exclude .log files
     assert excl.exclude_file("skip.log")
     # keep.py should be allowed
@@ -37,3 +39,26 @@ def test_excluder_env_overrides(tmp_path, monkeypatch):
     excl = ing._Excluder(root)
     assert not excl.exclude_dir("/.git")  # defaults off
     assert excl.exclude_file("a/file.tmp")
+
+
+def test_remote_git_history_manifest_detection(tmp_path):
+    p = tmp_path / ".remote-git" / "git_history_test.json"
+    assert ing._should_skip_explicit_file_by_excluder(p)
+
+
+def test_iter_files_single_file_skips_excluded_remote_git_manifest(tmp_path):
+    p = tmp_path / ".remote-git" / "git_history_test.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{}\n")
+
+    assert ing._should_skip_explicit_file_by_excluder(p)
+    assert list(ing.iter_files(p)) == []
+
+
+def test_excluder_default_excludes_remote_git_nested(tmp_path):
+    root = tmp_path
+    repo = root / "repo"
+    (repo / ".remote-git").mkdir(parents=True, exist_ok=True)
+
+    excl = ing._Excluder(root)
+    assert excl.exclude_dir("/repo/.remote-git")


### PR DESCRIPTION
… scans

When indexing /work in dev-remote, repos live under /work/<repo>/..., so the default dir exclude "/.remote-git" did not prune nested ".remote-git" folders. This caused git_history_*.json manifests to be indexed as code.

Treat root-style single-segment exclude prefixes (e.g. "/.remote-git", "/.git") as "exclude-by-basename anywhere" to correctly prune nested repo metadata dirs. Add a regression test for /repo/.remote-git exclusion.