### PR TITLE
fix(vscode-ext): pass auth password via env to avoid Windows cmd esca…

### DIFF
--- a/vscode-extension/context-engine-uploader/auth_utils.js
+++ b/vscode-extension/context-engine-uploader/auth_utils.js
@@ -208,9 +208,15 @@ async function runAuthLoginFlow(explicitBackendUrl, deps) {
     return;
   }
 
-  const args = [...invocation.args, 'auth', 'login', '--backend-url', backendUrl, '--username', username, '--password', password];
+  const args = [...invocation.args, 'auth', 'login'];
+  const env = {
+    ...process.env,
+    CTXCE_AUTH_BACKEND_URL: backendUrl,
+    CTXCE_AUTH_USERNAME: username,
+    CTXCE_AUTH_PASSWORD: password,
+  };
   await new Promise(resolve => {
-    const child = spawn(invocation.command, args, { cwd, env: process.env });
+    const child = spawn(invocation.command, args, { cwd, env });
     attachOutput(child, 'auth');
     child.on('error', error => {
       log(`ctxce auth login failed to start: ${error instanceof Error ? error.message : String(error)}`);

--- a/vscode-extension/context-engine-uploader/package.json
+++ b/vscode-extension/context-engine-uploader/package.json
@@ -2,7 +2,7 @@
   "name": "context-engine-uploader",
   "displayName": "Context Engine Uploader",
   "description": "Runs the Context-Engine remote upload client with a force sync on startup followed by watch mode. Requires Python with pip install requests urllib3 charset_normalizer.",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "publisher": "context-engine",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
…ping

On Windows the extension invokes the bridge via `cmd /c npx ...`, so passwords containing `&` were treated as command separators and broke `auth login`. Switch username/password login to use CTXCE_AUTH_USERNAME/CTXCE_AUTH_PASSWORD (and CTXCE_AUTH_BACKEND_URL) instead of CLI args.