### PR TITLE
fix(create_indexes): make init job multi-repo aware and import-safe

### DIFF
--- a/deploy/kubernetes/indexer-services.yaml
+++ b/deploy/kubernetes/indexer-services.yaml
@@ -255,8 +255,9 @@ spec:
         image: context-engine-indexer-service
         imagePullPolicy: IfNotPresent
         command:
-        - python
-        - /app/scripts/create_indexes.py
+        - /bin/sh
+        - -c
+        - PYTHONPATH=/app python /app/scripts/create_indexes.py && PYTHONPATH=/app python /app/scripts/warm_all_collections.py && PYTHONPATH=/app python /app/scripts/health_check.py
         workingDir: /work
         env:
         - name: QDRANT_URL


### PR DESCRIPTION
- Ensure repo root is on sys.path so `scripts.*` imports work when run as /app/scripts/create_indexes.py (K8s Job)
- Respect QDRANT_TIMEOUT when constructing QdrantClient to reduce init flakiness under load
- Document why create_indexes is a no-op in MULTI_REPO_MODE when WS_PATH=/work (per-repo collections handle indexes elsewhere)