### PR TITLE
fix: Add ARM64 support and static linking to llamacpp Dockerfile

### DIFF
--- a/Dockerfile.llamacpp
+++ b/Dockerfile.llamacpp
@@ -2,20 +2,20 @@
 # Production note: choose a tiny GGUF model (e.g., tinyllama) in ./models/model.gguf
 FROM debian:bookworm-slim AS build
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git build-essential cmake curl ca-certificates && rm -rf /var/lib/apt/lists/*
+    git build-essential cmake curl ca-certificates libcurl4-openssl-dev && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 RUN git clone --depth=1 https://github.com/ggerganov/llama.cpp.git
 WORKDIR /src/llama.cpp
-RUN cmake -S . -B build -DLLAMA_BUILD_SERVER=ON && cmake --build build -j
+RUN cmake -S . -B build -DLLAMA_BUILD_SERVER=ON -DBUILD_SHARED_LIBS=OFF && cmake --build build -j
 
 FROM debian:bookworm-slim
 ARG MODEL_URL=""
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl && rm -rf /var/lib/apt/lists/*
+    ca-certificates curl libgomp1 libcurl4 && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
-COPY --from=build /src/llama.cpp/build/bin/server /app/server
+COPY --from=build /src/llama.cpp/build/bin/llama-server /app/llama-server
 # Optionally bake a model into the image if MODEL_URL is provided
 RUN mkdir -p /models \
     && if [ -n "$MODEL_URL" ]; then echo "Fetching model: $MODEL_URL" && curl -L --fail --retry 3 -C - "$MODEL_URL" -o /models/model.gguf; else echo "No MODEL_URL provided; expecting host volume /models"; fi
 EXPOSE 8080
-ENTRYPOINT ["/app/server", "--model", "/models/model.gguf", "--host", "0.0.0.0", "--port", "8080", "--no-warmup"]
+ENTRYPOINT ["/app/llama-server"]


### PR DESCRIPTION
- Add libcurl4-openssl-dev build dependency for CURL support
- Enable static linking with -DBUILD_SHARED_LIBS=OFF for portability
- Update binary path from 'server' to 'llama-server' (latest llama.cpp)
- Add runtime dependencies: libgomp1, libcurl4
- Remove hardcoded ENTRYPOINT args for flexibility
- Fixes 'exec format error' on ARM64 systems
- Fixes 'unknown model architecture: qwen2' error with older llama.cpp

Tested on Oracle Cloud ARM64 (aarch64) with Qwen2.5-Coder-7B-Instruct model. Static build ensures portability across different ARM64 environments.