### PR TITLE
Regression fix:(workspace_state): avoid repo_name='work' for /work/<r…

### DIFF
--- a/scripts/workspace_state.py
+++ b/scripts/workspace_state.py
@@ -292,6 +292,28 @@ def _detect_repo_name_from_path(path: Path) -> str:
     3. Walk up to find .git and return that folder name
     4. Return parent folder name as fallback
     """
+    # Fast-path for managed upload workspaces (typically mounted at /work):
+    # derive the repo name from the first path segment relative to the workspace
+    # root instead of spawning git processes or falling back to "work".
+    try:
+        ws_root = Path(_resolve_workspace_root()).resolve()
+    except Exception:
+        ws_root = Path(_resolve_workspace_root())
+
+    try:
+        resolved = path.resolve()
+    except Exception:
+        resolved = path if path.is_dir() else path.parent
+
+    try:
+        rel = resolved.relative_to(ws_root)
+        if rel.parts:
+            candidate = rel.parts[0]
+            if candidate not in {".codebase", ".git", "__pycache__"}:
+                return candidate
+    except Exception:
+        pass
+
     try:
         base = path if path.is_dir() else path.parent
         # First try: get repo name from git remote origin URL (canonical name)
@@ -330,6 +352,14 @@ def _detect_repo_name_from_path(path: Path) -> str:
                 continue
     except Exception:
         pass
+
+    try:
+        structure_name = _detect_repo_name_from_path_by_structure(path)
+        if structure_name:
+            return structure_name
+    except Exception:
+        pass
+
     return (path if path.is_dir() else path.parent).name or "workspace"
 
 
@@ -701,7 +731,7 @@ def _detect_repo_name_from_path_by_structure(path: Path) -> str:
             continue
 
         repo_path = base / repo_name
-        if repo_path.exists() or str(resolved_path).startswith(str(repo_path) + os.sep):
+        if repo_path.exists() or resolved_path == repo_path or str(resolved_path).startswith(str(repo_path) + os.sep):
             return repo_name
 
     return None
@@ -716,6 +746,13 @@ def _extract_repo_name_from_path(workspace_path: str) -> str:
 
     # First try git-based detection (uses remote origin URL for canonical name)
     git_name = _detect_repo_name_from_path(path)
+    if git_name:
+        try:
+            ws_root = Path(_resolve_workspace_root()).resolve()
+        except Exception:
+            ws_root = Path(_resolve_workspace_root())
+        if ws_root.name and git_name == ws_root.name:
+            git_name = None
     if git_name and git_name != "workspace":
         return git_name
 

--- a/tests/test_workspace_state_repo_detection.py
+++ b/tests/test_workspace_state_repo_detection.py
@@ -1,0 +1,24 @@
+import importlib
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_extract_repo_name_uses_workspace_relative_leaf(monkeypatch, tmp_path):
+    ws_root = tmp_path / "work"
+    ws_root.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("WORKSPACE_PATH", str(ws_root))
+
+    ws = importlib.import_module("scripts.workspace_state")
+    ws = importlib.reload(ws)
+
+    def _no_git(*_args, **_kwargs):
+        raise AssertionError("git detection should not run for workspace-root-relative paths")
+
+    monkeypatch.setattr(ws.subprocess, "run", _no_git, raising=True)
+
+    repo_path = ws_root / "Context-Engine"
+    assert not repo_path.exists()
+    assert ws._extract_repo_name_from_path(str(repo_path)) == "Context-Engine"


### PR DESCRIPTION
…epo> paths without git metadata

Upstream repo-name detection began prioritizing git remote/toplevel metadata. In upload-managed (non-bindmount) deployments, /work is a workspace root and /work/<repo> may not exist yet when name resolution runs (pre-extraction). When git detection fails, the previous fallback could return the parent folder name ("work"), producing work-<hash> collections/workspaces.

Fix by:
- Adding a fast-path for paths under the workspace root (e.g. /work) to derive the repo name from the first relative path segment instead of spawning git.
- Keeping structure-based detection available as a fallback.
- Hardening structure detection to treat resolved_path == base/repo as valid so non-existent-but-intended repo roots don’t fall through.
- Preventing _extract_repo_name_from_path from accepting the workspace-root name as a valid repo identifier.

Add a unit regression test ensuring _extract_repo_name_from_path returns the repo leaf for workspace-root-relative paths even before the repo directory exists. Also asserts git subprocess calls are not used for this case.

This restores correct repo/collection naming for remote uploads without relying on bind-mounted git metadata. Regression introduced in commit: 6606c02c18780164696ccdcdf73066d4ebab58d9