### PR TITLE
Dirty queue poc

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@ QDRANT_URL=http://localhost:6333
 # Multi-repo: Each subdirectory gets its own collection
 MULTI_REPO_MODE=0
 
+# Dirty-ops queue fast reconcile (server-managed uploads)
+# 0=disable, 1=enable; when unset, defaults to enabled only for repos marked server-managed.
+# INDEX_DIRTY_QUEUE_ENABLED=0
+# Force a full scan even if dirty-ops queue is enabled
+# INDEX_DIRTY_QUEUE_FORCE_FULL_SCAN=0
+
 # Logical repo reuse (experimental): 0=disabled (default), 1=enable logical_repo_id-based
 # collection reuse across git worktrees / clones. When enabled, indexer, watcher, and
 # upload service will try to reuse a canonical collection per logical repository and

--- a/scripts/dirty_queue.py
+++ b/scripts/dirty_queue.py
@@ -9,6 +9,12 @@ from typing import Any, Callable
 from qdrant_client import QdrantClient
 
 
+# TODO(NEON_WARNING): VS Code "force reindex" uses standalone_upload_client.py --force, which treats all files as
+# created and can generate repo-wide dirty ops (nullifying the dirty-queue fast-path). Consider separating "reindex"
+# vs "force upload", and/or adding bulk-marker/threshold fallback; keep force-upload as an escape hatch when
+# client/server state diverges.
+
+
 def _env_truthy(val: str | None, default: bool) -> bool:
     if val is None:
         return default

--- a/scripts/dirty_queue.py
+++ b/scripts/dirty_queue.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from qdrant_client import QdrantClient
+
+
+def _env_truthy(val: str | None, default: bool) -> bool:
+    if val is None:
+        return default
+    return val.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class DirtyQueueHooks:
+    cross_process_lock: Any | None
+    get_collection_for_file: Callable[[Path], str] | None
+    sanitize_vector_name: Callable[[str], str]
+    ensure_collection_and_indexes_once: Callable[[QdrantClient, str, int, str], Any]
+    index_single_file: Callable[..., bool]
+    delete_points_by_path: Callable[[QdrantClient, str, str], Any]
+    remove_cached_file: Callable[[str, str], Any] | None
+    remove_cached_symbols: Callable[[str], Any] | None
+    lex_vector_name: str
+    mini_vector_name: str
+
+
+def _pick_vector_name_for_collection(
+    client: QdrantClient,
+    collection: str,
+    *,
+    dim: int,
+    model_name: str,
+    hooks: DirtyQueueHooks,
+) -> str:
+    vn: str | None = None
+    try:
+        info = client.get_collection(collection)
+        cfg = info.config.params.vectors
+        if isinstance(cfg, dict) and cfg:
+            # Prefer named vector whose size matches current embedding dim
+            for name, params in cfg.items():
+                psize = getattr(params, "size", None) or getattr(params, "dim", None)
+                if psize and int(psize) == int(dim):
+                    vn = name
+                    break
+            # Otherwise, if a lex vector exists, pick a different name as dense
+            if vn is None and hooks.lex_vector_name in cfg:
+                for name in cfg.keys():
+                    if name != hooks.lex_vector_name:
+                        vn = name
+                        break
+    except Exception:
+        vn = None
+    if vn is None:
+        vn = hooks.sanitize_vector_name(model_name)
+    return vn
+
+
+def _dirty_queue_default_enabled(root: Path, *, is_multi_repo: bool) -> bool:
+    if not is_multi_repo:
+        return False
+
+    work_dir = Path(os.environ.get("WORK_DIR") or os.environ.get("WORKDIR") or "/work")
+    repos_dir = work_dir / ".codebase" / "repos"
+
+    try:
+        root_res = root.resolve()
+    except Exception:
+        root_res = root
+    try:
+        work_res = work_dir.resolve()
+    except Exception:
+        work_res = work_dir
+
+    try:
+        rel = root_res.relative_to(work_res)
+    except Exception:
+        return False
+    if len(rel.parts) != 1:
+        return False
+    slug = rel.parts[0]
+    if not slug:
+        return False
+
+    try:
+        return (repos_dir / slug / ".ctxce_managed_upload").exists()
+    except Exception:
+        return False
+
+
+def _dirty_queue_enabled(root: Path, *, is_multi_repo: bool) -> bool:
+    return _env_truthy(
+        os.environ.get("INDEX_DIRTY_QUEUE_ENABLED"),
+        _dirty_queue_default_enabled(root, is_multi_repo=is_multi_repo),
+    )
+
+
+def _dirty_queue_force_full_scan() -> bool:
+    return _env_truthy(os.environ.get("INDEX_DIRTY_QUEUE_FORCE_FULL_SCAN"), False)
+
+
+def _drain_dirty_ops(root: Path, *, hooks: DirtyQueueHooks) -> list[dict[str, Any]] | None:
+    work_dir = Path(os.environ.get("WORK_DIR") or os.environ.get("WORKDIR") or "/work")
+    repos_dir = work_dir / ".codebase" / "repos"
+
+    try:
+        if not repos_dir.exists():
+            return []
+    except Exception:
+        return None
+
+    try:
+        root_res = root.resolve()
+    except Exception:
+        root_res = root
+    try:
+        work_res = work_dir.resolve()
+    except Exception:
+        work_res = work_dir
+
+    try:
+        rel = root_res.relative_to(work_res)
+    except Exception:
+        return None
+    if len(rel.parts) != 1:
+        return None
+    slug = rel.parts[0]
+    if not slug:
+        return None
+
+    repo_dir = repos_dir / slug
+    try:
+        if not (repo_dir / ".ctxce_managed_upload").exists():
+            return None
+    except Exception:
+        return None
+
+    queue_path = repo_dir / "dirty_ops.jsonl"
+    try:
+        if not queue_path.exists():
+            return []
+    except Exception:
+        return None
+
+    lock_path = queue_path.with_suffix(queue_path.suffix + ".lock")
+
+    lines: list[str] = []
+    try:
+        if hooks.cross_process_lock is not None:
+            with hooks.cross_process_lock(lock_path):
+                try:
+                    with open(queue_path, "r", encoding="utf-8") as f:
+                        lines = f.readlines()
+                except FileNotFoundError:
+                    lines = []
+                try:
+                    with open(queue_path, "w", encoding="utf-8"):
+                        pass
+                except Exception:
+                    pass
+        else:
+            try:
+                with open(queue_path, "r", encoding="utf-8") as f:
+                    lines = f.readlines()
+            except FileNotFoundError:
+                lines = []
+            try:
+                with open(queue_path, "w", encoding="utf-8"):
+                    pass
+            except Exception:
+                pass
+    except Exception:
+        return None
+
+    out: list[dict[str, Any]] = []
+    for ln in lines:
+        s = (ln or "").strip()
+        if not s:
+            continue
+        try:
+            obj = json.loads(s)
+        except Exception:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        rec = dict(obj)
+        rec.setdefault("repo", slug)
+        out.append(rec)
+
+    return out
+
+
+def _index_dirty_ops(
+    ops: list[dict[str, Any]],
+    *,
+    root: Path,
+    qdrant_url: str,
+    api_key: str,
+    collection: str,
+    model_name: str,
+    dedupe: bool,
+    pseudo_mode: str,
+    hooks: DirtyQueueHooks,
+) -> None:
+    try:
+        from scripts.embedder import get_embedding_model, get_model_dimension
+
+        model = get_embedding_model(model_name)
+        dim = get_model_dimension(model_name)
+    except ImportError:
+        try:
+            from fastembed import TextEmbedding  # type: ignore
+        except Exception:
+            try:
+                print("[dirty_queue] fastembed not available; cannot index")
+            except Exception:
+                pass
+            return
+        model = TextEmbedding(model_name=model_name)
+        dim = len(next(model.embed(["dimension probe"])))
+
+    client = QdrantClient(
+        url=qdrant_url,
+        api_key=api_key or None,
+        timeout=int(os.environ.get("QDRANT_TIMEOUT", "20") or 20),
+    )
+
+    work_dir = Path(os.environ.get("WORK_DIR") or os.environ.get("WORKDIR") or "/work")
+    vector_name_by_collection: dict[str, str] = {}
+
+    processed = 0
+    deleted = 0
+    moved = 0
+    indexed = 0
+
+    for rec in ops:
+        processed += 1
+        op = (rec.get("op") or "").strip().lower()
+        repo = (rec.get("repo") or "").strip()
+        rel_path = rec.get("path")
+        if not repo or not isinstance(rel_path, str) or not rel_path:
+            continue
+
+        repo_root = work_dir / repo
+        file_path = repo_root / rel_path
+
+        current_collection = collection
+        try:
+            if hooks.get_collection_for_file:
+                current_collection = hooks.get_collection_for_file(file_path)
+        except Exception:
+            current_collection = collection
+        if not current_collection:
+            continue
+
+        if op == "deleted":
+            try:
+                hooks.delete_points_by_path(client, current_collection, str(file_path))
+            except Exception:
+                pass
+            try:
+                if hooks.remove_cached_file:
+                    hooks.remove_cached_file(str(file_path), repo)
+            except Exception:
+                pass
+            try:
+                if hooks.remove_cached_symbols:
+                    hooks.remove_cached_symbols(str(file_path))
+            except Exception:
+                pass
+            deleted += 1
+            continue
+
+        if op == "moved":
+            source_rel = rec.get("source_path") or rec.get("source_relative_path")
+            if isinstance(source_rel, str) and source_rel:
+                old_path = repo_root / source_rel
+                try:
+                    hooks.delete_points_by_path(client, current_collection, str(old_path))
+                except Exception:
+                    pass
+                try:
+                    if hooks.remove_cached_file:
+                        hooks.remove_cached_file(str(old_path), repo)
+                except Exception:
+                    pass
+                try:
+                    if hooks.remove_cached_symbols:
+                        hooks.remove_cached_symbols(str(old_path))
+                except Exception:
+                    pass
+            moved += 1
+
+        try:
+            if not file_path.exists():
+                continue
+        except Exception:
+            continue
+
+        vn = vector_name_by_collection.get(current_collection)
+        if not vn:
+            vn = _pick_vector_name_for_collection(
+                client,
+                current_collection,
+                dim=dim,
+                model_name=model_name,
+                hooks=hooks,
+            )
+            vector_name_by_collection[current_collection] = vn
+
+        try:
+            hooks.ensure_collection_and_indexes_once(client, current_collection, dim, vn)
+        except Exception:
+            continue
+
+        try:
+            ok = hooks.index_single_file(
+                client,
+                model,
+                current_collection,
+                vector_name_by_collection[current_collection],
+                file_path,
+                dedupe=dedupe,
+                skip_unchanged=True,
+                pseudo_mode=pseudo_mode,
+                repo_name_for_cache=repo,
+            )
+            if ok:
+                indexed += 1
+        except Exception:
+            pass
+
+    try:
+        print(
+            f"[dirty_queue] processed={processed} indexed={indexed} deleted={deleted} moved={moved}"
+        )
+    except Exception:
+        pass
+
+
+def maybe_process_dirty_queue(
+    *,
+    root: Path,
+    qdrant_url: str,
+    api_key: str,
+    collection: str,
+    model_name: str,
+    recreate: bool,
+    dedupe: bool,
+    skip_unchanged: bool,
+    pseudo_mode: str,
+    is_multi_repo: bool,
+    hooks: DirtyQueueHooks,
+) -> str:
+    if recreate or not skip_unchanged:
+        return "fallback_scan"
+    if _dirty_queue_force_full_scan():
+        return "fallback_scan"
+    if not _dirty_queue_enabled(root, is_multi_repo=is_multi_repo):
+        return "fallback_scan"
+
+    ops = _drain_dirty_ops(root, hooks=hooks)
+    if ops is None:
+        try:
+            print("[dirty_queue] Failed to drain queue; falling back to full scan")
+        except Exception:
+            pass
+        return "fallback_scan"
+
+    if not ops:
+        try:
+            print("[dirty_queue] No pending ops; skipping full scan")
+        except Exception:
+            pass
+        return "no_op"
+
+    _index_dirty_ops(
+        ops,
+        root=root,
+        qdrant_url=qdrant_url,
+        api_key=api_key,
+        collection=collection,
+        model_name=model_name,
+        dedupe=dedupe,
+        pseudo_mode=pseudo_mode,
+        hooks=hooks,
+    )
+    return "processed"

--- a/scripts/ingest_code.py
+++ b/scripts/ingest_code.py
@@ -16,6 +16,7 @@ def _detect_repo_name_from_path(path: Path) -> str:
 import os
 import sys
 import argparse
+import json
 import hashlib
 import re
 import ast
@@ -35,6 +36,12 @@ if str(ROOT_DIR) not in sys.path:
 
 
 from qdrant_client import QdrantClient, models
+
+try:
+    from scripts.dirty_queue import DirtyQueueHooks, maybe_process_dirty_queue
+except ImportError:
+    DirtyQueueHooks = None  # type: ignore
+    maybe_process_dirty_queue = None  # type: ignore
 
 # Use embedder factory for Qwen3 support; fallback to direct fastembed
 try:
@@ -96,6 +103,7 @@ try:
         update_symbols_with_pseudo,
         get_workspace_state,
         get_cached_file_meta,
+        _cross_process_lock,
     )
 except ImportError:
     # State integration is optional; continue if not available
@@ -114,6 +122,7 @@ except ImportError:
     compare_symbol_changes = None  # type: ignore
     get_workspace_state = None  # type: ignore
     get_cached_file_meta = None  # type: ignore
+    _cross_process_lock = None  # type: ignore
 
 # Optional Tree-sitter import (graceful fallback) - tree-sitter 0.25+ API
 _TS_LANGUAGES: Dict[str, Any] = {}
@@ -3044,6 +3053,43 @@ def index_repo(
     skip_unchanged: bool = True,
     pseudo_mode: str = "full",
 ):
+    try:
+        is_multi_repo = bool(is_multi_repo_mode and is_multi_repo_mode())
+    except Exception:
+        is_multi_repo = False
+
+    try:
+        if maybe_process_dirty_queue is not None and DirtyQueueHooks is not None:
+            hooks = DirtyQueueHooks(
+                cross_process_lock=_cross_process_lock,
+                get_collection_for_file=_get_collection_for_file,
+                sanitize_vector_name=_sanitize_vector_name,
+                ensure_collection_and_indexes_once=ensure_collection_and_indexes_once,
+                index_single_file=index_single_file,
+                delete_points_by_path=delete_points_by_path,
+                remove_cached_file=remove_cached_file,
+                remove_cached_symbols=remove_cached_symbols,
+                lex_vector_name=LEX_VECTOR_NAME,
+                mini_vector_name=MINI_VECTOR_NAME,
+            )
+            mode = maybe_process_dirty_queue(
+                root=root,
+                qdrant_url=qdrant_url,
+                api_key=api_key,
+                collection=collection,
+                model_name=model_name,
+                recreate=recreate,
+                dedupe=dedupe,
+                skip_unchanged=skip_unchanged,
+                pseudo_mode=pseudo_mode,
+                is_multi_repo=is_multi_repo,
+                hooks=hooks,
+            )
+            if mode != "fallback_scan":
+                return
+    except Exception:
+        pass
+
     # Optional fast no-change precheck: when INDEX_FS_FASTPATH is enabled, use
     # fs metadata + cache.json to exit early before model/Qdrant setup when all
     # files are unchanged.

--- a/scripts/upload_delta_bundle.py
+++ b/scripts/upload_delta_bundle.py
@@ -4,6 +4,7 @@ import tarfile
 import hashlib
 import re
 import logging
+import time
 from pathlib import Path
 from typing import Dict, Any
 
@@ -12,6 +13,11 @@ try:
     from scripts.workspace_state import _extract_repo_name_from_path
 except ImportError:
     _extract_repo_name_from_path = None
+
+try:
+    from scripts.workspace_state import _cross_process_lock
+except ImportError:
+    _cross_process_lock = None
 
 
 logger = logging.getLogger(__name__)
@@ -93,12 +99,14 @@ def process_delta_bundle(workspace_path: str, bundle_path: Path, manifest: Dict[
         # Server-side marker for admin cleanup: stored with metadata (not inside repo tree)
         # so admin delete actions don't risk deleting bind-mounted /work repos in non-remote
         # docker-compose setups.
+        marker_dir = Path(WORK_DIR) / ".codebase" / "repos" / slug_repo_name
         try:
-            marker_dir = Path(WORK_DIR) / ".codebase" / "repos" / slug_repo_name
             marker_dir.mkdir(parents=True, exist_ok=True)
             (marker_dir / ".ctxce_managed_upload").write_text("1\n")
         except Exception:
             pass
+
+        dirty_ops: list[dict[str, Any]] = []
 
         workspace_root = workspace.resolve()
 
@@ -203,6 +211,13 @@ def process_delta_bundle(workspace_path: str, bundle_path: Path, manifest: Dict[
                                 target_path.parent.mkdir(parents=True, exist_ok=True)
                                 target_path.write_bytes(file_content.read())
                                 operations_count["created"] += 1
+                                dirty_ops.append(
+                                    {
+                                        "op": "created",
+                                        "path": rel_path,
+                                        "ts": int(time.time()),
+                                    }
+                                )
                             else:
                                 operations_count["failed"] += 1
                         else:
@@ -221,6 +236,13 @@ def process_delta_bundle(workspace_path: str, bundle_path: Path, manifest: Dict[
                                 target_path.parent.mkdir(parents=True, exist_ok=True)
                                 target_path.write_bytes(file_content.read())
                                 operations_count["updated"] += 1
+                                dirty_ops.append(
+                                    {
+                                        "op": "updated",
+                                        "path": rel_path,
+                                        "ts": int(time.time()),
+                                    }
+                                )
                             else:
                                 operations_count["failed"] += 1
                         else:
@@ -239,6 +261,14 @@ def process_delta_bundle(workspace_path: str, bundle_path: Path, manifest: Dict[
                                 target_path.parent.mkdir(parents=True, exist_ok=True)
                                 target_path.write_bytes(file_content.read())
                                 operations_count["moved"] += 1
+                                dirty_ops.append(
+                                    {
+                                        "op": "moved",
+                                        "path": rel_path,
+                                        "source_path": source_rel_path,
+                                        "ts": int(time.time()),
+                                    }
+                                )
                             else:
                                 operations_count["failed"] += 1
                         else:
@@ -260,6 +290,13 @@ def process_delta_bundle(workspace_path: str, bundle_path: Path, manifest: Dict[
                             target_path.unlink()
                             _cleanup_empty_dirs(target_path.parent, workspace)
                             operations_count["deleted"] += 1
+                            dirty_ops.append(
+                                {
+                                    "op": "deleted",
+                                    "path": rel_path,
+                                    "ts": int(time.time()),
+                                }
+                            )
                         else:
                             operations_count["skipped"] += 1
 
@@ -269,6 +306,22 @@ def process_delta_bundle(workspace_path: str, bundle_path: Path, manifest: Dict[
                 except Exception as e:
                     logger.error(f"Error processing operation {op_type} for {rel_path}: {e}")
                     operations_count["failed"] += 1
+
+        if dirty_ops:
+            try:
+                queue_path = marker_dir / "dirty_ops.jsonl"
+                lock_path = queue_path.with_suffix(queue_path.suffix + ".lock")
+                if _cross_process_lock is not None:
+                    with _cross_process_lock(lock_path):
+                        with open(queue_path, "a", encoding="utf-8") as f:
+                            for rec in dirty_ops:
+                                f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+                else:
+                    with open(queue_path, "a", encoding="utf-8") as f:
+                        for rec in dirty_ops:
+                            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+            except Exception:
+                pass
 
         return operations_count
 


### PR DESCRIPTION
## Summary

Proof-of-concept: introduce a server-managed “dirty queue” to reconcile file-level changes received via remote uploads without scanning the entire repository. When enabled, the server records granular operations (created/updated/moved/deleted) to a per-repo queue and, during indexing, drains the queue to index only the affected files. The system falls back to a full scan when unavailable or misconfigured.

Status: PoC behind env flags; defaults to off except for server-managed multi-repo workspaces.

## Motivation

Full repository scans after remote uploads are costly and unnecessary when only a small subset of files changed. This PoC aims to:
- Reduce indexing latency and Qdrant load by operating on a minimal set of changed files.
- Avoid repeated Qdrant collection pings and expensive filesystem metadata calls during unchanged runs.
- Provide safe fallback paths to preserve reliability.

## How it works (high level)

1. Server-side upload handling (upload_delta_bundle):
   - Applies incoming changes to the managed workspace.
   - Appends a compact record of each operation to /.codebase/repos/<slug>/dirty_ops.jsonl.
   - Marks the repo as “server-managed” via .ctxce_managed_upload.

2. Indexing entrypoint (ingest_code.index_repo):
   - If the dirty queue is enabled and conditions allow, drain dirty_ops.jsonl and index only the referenced files.
   - For deletions/moves, delete associated Qdrant points and clean symbol/file caches.
   - If the queue is missing, unreadable, or disabled, fall back to the existing full-scan logic.

3. Qdrant usage:
   - Derives or selects the appropriate named vector for the collection (prefers existing dim match).
   - Ensures collection/indexes at most once (optional periodic ping configurable).

## Key changes

- .env.example
  - INDEX_DIRTY_QUEUE_ENABLED: 0/1; enable fast reconcile mode.
  - INDEX_DIRTY_QUEUE_FORCE_FULL_SCAN: 0/1; bypass the queue and force full scan.
- scripts/upload_delta_bundle.py
  - Records created/updated/moved/deleted operations with timestamps to dirty_ops.jsonl.
  - Writes .ctxce_managed_upload to identify server-managed repos.
  - Uses a cross-process lock when appending queue entries.
- scripts/dirty_queue.py (new)
  - Drains and parses dirty_ops.jsonl with locking.
  - Deletes Qdrant points for deleted/moved paths and re-indexes touched files only.
  - Picks an existing named vector matching current embedding dimension when possible.
  - Safe fallbacks: returns “fallback_scan” when disabled/unavailable; “no_op” when queue is empty; “processed” when handled.
- scripts/ingest_code.py
  - Integrates DirtyQueueHooks and maybe_process_dirty_queue at the start of index_repo.
  - Reduces filesystem overhead (prefer os.path over resolve) and improves progress reporting (postfix counters for skipped by fs meta/cache/Qdrant).
  - Optional ENSURED_COLLECTION_PING_SECONDS to rate-limit GET /collections calls.
  - Passes repo_name_for_cache through indexing paths to align cache keys.
  - Numerous cache/skip-path refinements for single/multi-repo modes.
- scripts/workspace_state.py
  - Normalizes cache key paths with abspath; adds memoized cache reads with signature checks and configurable CACHE_MEMO_RECHECK_SECONDS.
  - UTF-8 BOM tolerant reads for state and cache files.
  - Server-managed slug detection and symbol cache path normalization.
  - Atomic writes are memoized to keep in-process views consistent.
- scripts/watch_index.py
  - Threads repo_name_for_cache down to index_single_file to improve cache hits.

## Configuration

- Default enablement:
  - If INDEX_DIRTY_QUEUE_ENABLED is unset, the queue is auto-enabled only for multi-repo workspaces that are server-managed (presence of /.codebase/repos/<slug>/.ctxce_managed_upload).
- Recommended PoC settings:
  - INDEX_DIRTY_QUEUE_ENABLED=1 (for target server-managed repos)
  - ENSURED_COLLECTION_PING_SECONDS=60 (optional; trims control-plane chatter)
  - CACHE_MEMO_RECHECK_SECONDS=60 (default; tune for your workload)

## Performance considerations

- Avoids full repo scans when the queue is present by indexing only changed files.
- Reduces repeated Qdrant GET calls for collections via rate-limited ping.
- Minimizes expensive filesystem metadata calls (abspath vs resolve, cached state).
- Adds progress-bar postfix with counters for skipped cases to improve operator visibility.

## Correctness and failure modes

- If the queue cannot be drained (missing/unreadable), or when recreate/skip_unchanged conditions require, the indexer falls back to a full scan.
- Deleted/moved operations remove corresponding Qdrant points and clear file/symbol caches.
- Queue writes are lock-protected to prevent corruption; reads also support locking when available.
- VS Code “force reindex” currently issues a repo-wide “created” set; this can negate the queue’s benefits (tracked in TODO).

## Limitations (PoC)

- Queue semantics are best-effort; malformed lines are ignored.
- Granularity is per file; intra-file symbol-level deltas remain future work.
- VS Code “force reindex” conflates reindex vs force-upload; needs UX and client separation.
- No dedicated unit tests for dirty_queue yet; guarded by fallbacks.

## Testing / validation plan

- Functional:
  - Enable INDEX_DIRTY_QUEUE_ENABLED=1 for a server-managed repo.
  - Upload a delta bundle with a few file operations; confirm dirty_ops.jsonl appended.
  - Run ingest_code index_repo; observe “[dirty_queue] processed=… indexed=… deleted=… moved=…” and no initial full scan.
- Fallback:
  - Disable the flag or remove the queue file; confirm full-scan path executes.
- Cache behavior:
  - Validate fs-meta and cache-based skipping; confirm progress postfix updates (fsmeta/cache/qdrant).
- Qdrant:
  - Verify named vector selection and reduced GET /collections frequency under ENSURED_COLLECTION_PING_SECONDS.

## Rollout plan

- Stage behind INDEX_DIRTY_QUEUE_ENABLED for selected repos.
- Monitor indexing times, server CPU/IO, and Qdrant call volume.
- If stable, enable by default for all server-managed multi-repo workspaces.

## Future work

- Separate “force reindex” vs “force upload” flows in clients.
- Add unit tests for dirty queue draining, locking, and error handling.
- Extend queue format to batch operations and include symbol-diff hints.
- Telemetry hooks for queue length, drain time, and fallback counts.

## Risks

- Incorrect repo identity could misplace per-repo cache entries; mitigated by slug-based detection and consistent cache-key normalization.
- Queue growth if indexing is blocked; addressed by lock-safe appends and graceful fallbacks (but requires operational monitoring).
