### PR TITLE
ctx-mcp-bridge: normalize tool arg paths (path/under + glob) to workspace-relative

### DIFF
--- a/ctx-mcp-bridge/package.json
+++ b/ctx-mcp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-engine-bridge/context-engine-mcp-bridge",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Context Engine MCP bridge (http/stdio proxy combining indexer + memory servers)",
   "bin": {
     "ctxce": "bin/ctxce.js",

--- a/ctx-mcp-bridge/src/mcpServer.js
+++ b/ctx-mcp-bridge/src/mcpServer.js
@@ -10,7 +10,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { loadAnyAuthEntry, loadAuthEntry } from "./authConfig.js";
-import { maybeRemapToolResult } from "./resultPathMapping.js";
+import { maybeRemapToolArgs, maybeRemapToolResult } from "./resultPathMapping.js";
 
 function debugLog(message) {
   try {
@@ -502,6 +502,8 @@ async function createBridgeServer(options) {
       }
       args = obj;
     }
+
+    args = maybeRemapToolArgs(name, args, workspace);
 
     if (name === "set_session_defaults") {
       const indexerResult = await indexerClient.callTool({ name, arguments: args });

--- a/ctx-mcp-bridge/src/resultPathMapping.js
+++ b/ctx-mcp-bridge/src/resultPathMapping.js
@@ -28,6 +28,148 @@ function _posixToNative(rel) {
   }
 }
 
+function _nativeToPosix(p) {
+  try {
+    if (!p) {
+      return "";
+    }
+    return String(p).split(path.sep).join("/");
+  } catch {
+    return p;
+  }
+}
+
+function normalizeToolArgPath(p, workspaceRoot) {
+  try {
+    const s = typeof p === "string" ? p.trim() : "";
+    if (!s) {
+      return p;
+    }
+
+    const root = typeof workspaceRoot === "string" ? workspaceRoot : "";
+    const sPosix = s.replace(/\\/g, "/");
+
+    if (sPosix.startsWith("/work/")) {
+      const rest = sPosix.slice("/work/".length);
+      const parts = rest.split("/").filter(Boolean);
+      if (parts.length >= 2) {
+        return parts.slice(1).join("/");
+      }
+      if (parts.length === 1) {
+        return parts[0];
+      }
+      return p;
+    }
+
+    if (root) {
+      try {
+        const sNorm = s.replace(/\\/g, path.sep);
+        const rootNorm = root.replace(/\\/g, path.sep);
+        if (sNorm === rootNorm || sNorm.startsWith(rootNorm + path.sep)) {
+          const relNative = path.relative(rootNorm, sNorm);
+          const relPosix = _nativeToPosix(relNative);
+          if (relPosix && relPosix !== "." && relPosix !== ".." && !relPosix.startsWith("../")) {
+            return relPosix;
+          }
+        }
+      } catch {
+        // ignore
+      }
+      try {
+        const base = path.posix.basename(root.replace(/\\/g, "/"));
+        if (base && sPosix.startsWith(base + "/")) {
+          const rest = sPosix.slice((base + "/").length);
+          if (rest && rest !== "." && rest !== ".." && !rest.startsWith("../")) {
+            return rest;
+          }
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    if (sPosix.startsWith("./")) {
+      const rest = sPosix.slice(2);
+      if (rest && rest !== "." && rest !== ".." && !rest.startsWith("../")) {
+        return rest;
+      }
+    }
+    if (sPosix === ".") {
+      return "";
+    }
+    return p;
+  } catch {
+    return p;
+  }
+}
+
+function normalizeToolArgGlob(p, workspaceRoot) {
+  try {
+    const s = typeof p === "string" ? p : "";
+    if (!s) {
+      return p;
+    }
+    // TODO(ctxce): If this becomes annoying, consider making glob normalization
+    // more conservative (e.g. only strip a repo prefix when followed by "/",
+    // and avoid collapsing "<repo>/**" into "**" which can broaden scope).
+    if (s.startsWith("!")) {
+      const rest = s.slice(1);
+      const mapped = normalizeToolArgPath(rest, workspaceRoot);
+      if (typeof mapped === "string") {
+        return "!" + mapped;
+      }
+      return p;
+    }
+    return normalizeToolArgPath(s, workspaceRoot);
+  } catch {
+    return p;
+  }
+}
+
+function applyPathMappingToArgs(value, workspaceRoot, keyHint = "") {
+  try {
+    if (value === null || value === undefined) {
+      return value;
+    }
+
+    const key = typeof keyHint === "string" ? keyHint : "";
+    const lowered = key.toLowerCase();
+    const shouldMapString =
+      lowered === "path" ||
+      lowered === "under" ||
+      lowered === "root" ||
+      lowered === "subdir" ||
+      lowered === "path_glob" ||
+      lowered === "not_glob";
+
+    if (typeof value === "string") {
+      if (!shouldMapString) {
+        return value;
+      }
+      if (lowered === "path_glob" || lowered === "not_glob") {
+        return normalizeToolArgGlob(value, workspaceRoot);
+      }
+      return normalizeToolArgPath(value, workspaceRoot);
+    }
+
+    if (Array.isArray(value)) {
+      return value.map((v) => applyPathMappingToArgs(v, workspaceRoot, keyHint));
+    }
+
+    if (typeof value === "object") {
+      const out = { ...value };
+      for (const [k, v] of Object.entries(out)) {
+        out[k] = applyPathMappingToArgs(v, workspaceRoot, k);
+      }
+      return out;
+    }
+
+    return value;
+  } catch {
+    return value;
+  }
+}
+
 function computeWorkspaceRelativePath(containerPath, hostPath) {
   try {
     const cont = typeof containerPath === "string" ? containerPath.trim() : "";
@@ -334,5 +476,23 @@ export function maybeRemapToolResult(name, result, workspaceRoot) {
     return outResult;
   } catch {
     return result;
+  }
+}
+
+export function maybeRemapToolArgs(name, args, workspaceRoot) {
+  try {
+    if (!name || !workspaceRoot) {
+      return args;
+    }
+    const enabled = envTruthy(process.env.CTXCE_BRIDGE_MAP_ARGS, true);
+    if (!enabled) {
+      return args;
+    }
+    if (args === null || args === undefined || typeof args !== "object") {
+      return args;
+    }
+    return applyPathMappingToArgs(args, workspaceRoot, "");
+  } catch {
+    return args;
   }
 }


### PR DESCRIPTION


- Add request-side argument remapping in the MCP bridge so tool calls accept repo-prefixed and host-absolute workspace paths.
- Normalize path/under/root/subdir plus path_glob/not_glob (preserve leading '!').
- Exclude workspace/workspace_path/workspacePath from mapping to avoid semantic ambiguity.
- Add TODO note about making glob normalization more conservative if needed.