### PR TITLE
k8s: fix init-payload HF cache perms (mount models PVC + set cache env)

### DIFF
--- a/deploy/kubernetes/indexer-services.yaml
+++ b/deploy/kubernetes/indexer-services.yaml
@@ -312,6 +312,12 @@ spec:
             configMapKeyRef:
               name: context-engine-config
               key: COLLECTION_NAME
+        - name: HF_HOME
+          value: /work/models/hf-cache
+        - name: XDG_CACHE_HOME
+          value: /work/models/hf-cache
+        - name: HF_HUB_CACHE
+          value: /work/models/hf-cache/huggingface
         resources:
           requests:
             memory: 512Mi
@@ -324,6 +330,8 @@ spec:
           mountPath: /work
         - name: metadata-volume
           mountPath: /work/.codebase
+        - name: models-volume
+          mountPath: /work/models
         - name: metadata-volume
           mountPath: /tmp/rerank_weights
           subPath: rerank_weights
@@ -340,3 +348,6 @@ spec:
       - name: metadata-volume
         persistentVolumeClaim:
           claimName: code-metadata-pvc
+      - name: models-volume
+        persistentVolumeClaim:
+          claimName: code-models-pvc


### PR DESCRIPTION
Ensures init-payload mounts code-models-pvc at /work/models Sets HF_HOME / XDG_CACHE_HOME / HF_HUB_CACHE to /work/models/hf-cache to avoid writes to /.cache under runAsUser: 1000