### PR TITLE
docker: harden builds against pip timeouts

### DIFF
--- a/Dockerfile.indexer
+++ b/Dockerfile.indexer
@@ -3,14 +3,16 @@ FROM python:3.11-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    WORK_ROOTS="/work,/app"
+    WORK_ROOTS="/work,/app" \
+    PIP_DEFAULT_TIMEOUT=120 \
+    PIP_RETRIES=10
 
 # OS packages needed: git for history ingestion
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates && rm -rf /var/lib/apt/lists/*
 
 # Python deps: reuse shared requirements file
 COPY requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir --upgrade -r /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade --timeout=${PIP_DEFAULT_TIMEOUT} --retries=${PIP_RETRIES} -r /tmp/requirements.txt
 
 # Bake scripts into the image so we can mount arbitrary code at /work
 COPY scripts /app/scripts

--- a/Dockerfile.mcp-indexer
+++ b/Dockerfile.mcp-indexer
@@ -4,7 +4,9 @@ FROM python:3.11-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    WORK_ROOTS="/work,/app"
+    WORK_ROOTS="/work,/app" \
+    PIP_DEFAULT_TIMEOUT=120 \
+    PIP_RETRIES=10
 
 # OS deps (git for history if we extend later, curl for model downloads)
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates curl \
@@ -12,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git ca-certific
 
 # Python deps: reuse shared requirements (includes FastMCP + OpenAI SDK)
 COPY requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir --upgrade -r /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade --timeout=${PIP_DEFAULT_TIMEOUT} --retries=${PIP_RETRIES} -r /tmp/requirements.txt
 
 # Ensure rerank volumes are writable when containers run as non-root (uid 1000).
 # On first mount of an empty named volume, Docker copies directory contents (incl perms)


### PR DESCRIPTION
Set PIP_DEFAULT_TIMEOUT / PIP_RETRIES in Docker build env Pass --timeout/--retries to pip install -r requirements.txt in indexer images Reduces transient build failures when PyPI downloads are slow