### PR TITLE
context-engine-uploader: persist profiles across local/remote without Settings Sync

### DIFF
--- a/vscode-extension/context-engine-uploader/ctx_config.js
+++ b/vscode-extension/context-engine-uploader/ctx_config.js
@@ -109,6 +109,7 @@ function createCtxConfigManager(deps) {
             decoderRuntime = 'llamacpp';
           }
           useGpuDecoderSetting = !!uploaderSettings.get('useGpuDecoder', false);
+          // TODO: glmApiKey is read from settings.json (plaintext). Consider migrating API keys to VS Code SecretStorage (context.secrets) with backwards-compatible fallback.
           const cfgKey = (uploaderSettings.get('glmApiKey') || '').trim();
           const cfgBase = (uploaderSettings.get('glmApiBase') || '').trim();
           const cfgModel = (uploaderSettings.get('glmModel') || '').trim();

--- a/vscode-extension/context-engine-uploader/package.json
+++ b/vscode-extension/context-engine-uploader/package.json
@@ -2,7 +2,7 @@
   "name": "context-engine-uploader",
   "displayName": "Context Engine Uploader",
   "description": "Runs the Context-Engine remote upload client with a force sync on startup followed by watch mode. Requires Python with pip install requests urllib3 charset_normalizer.",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "publisher": "context-engine",
   "engines": {
     "vscode": "^1.85.0"
@@ -142,6 +142,14 @@
           "type": "boolean",
           "default": false,
           "description": "Run the force sync followed by watch after VS Code finishes startup."
+        },
+        "contextEngineUploader.profilesDb": {
+          "type": "object",
+          "default": {
+            "version": 1,
+            "profiles": []
+          },
+          "description": "Profiles database for Context Engine Uploader. Stored in VS Code user settings so it is available in Remote sessions without requiring Settings Sync sign-in."
         },
         "contextEngineUploader.pythonPath": {
           "type": "string",


### PR DESCRIPTION
Store profilesDb in VS Code user settings (inspect() to avoid schema-default masking). 

Keep backwards-compat by loading legacy profiles.json and migrating forward. 

Make saveProfilesDb async and await saves in wizards. 

Opt-in profiles + activeProfileId to globalState sync when available. 

Add TODO about migrating glmApiKey from settings.json to SecretStorage.