### PR TITLE
feat(vscode): extend Prompt+ actions + ctx_config default mode switch

### DIFF
--- a/vscode-extension/context-engine-uploader/package.json
+++ b/vscode-extension/context-engine-uploader/package.json
@@ -2,7 +2,7 @@
   "name": "context-engine-uploader",
   "displayName": "Context Engine Uploader",
   "description": "Runs the Context-Engine remote upload client with a force sync on startup followed by watch mode. Requires Python with pip install requests urllib3 charset_normalizer.",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "publisher": "context-engine",
   "engines": {
     "vscode": "^1.85.0"
@@ -19,6 +19,9 @@
     "onView:contextEngineUploaderStatus",
     "onView:contextEngineUploaderActions",
     "onCommand:contextEngineUploader.promptEnhance",
+    "onCommand:contextEngineUploader.promptEnhanceCopy",
+    "onCommand:contextEngineUploader.promptEnhanceOpen",
+    "onCommand:contextEngineUploader.setCtxDefaultMode",
     "onCommand:contextEngineUploader.authLogin",
     "onCommand:contextEngineUploader.writeMcpConfig",
     "onCommand:contextEngineUploader.writeMcpConfigSelect",
@@ -95,6 +98,18 @@
       {
         "command": "contextEngineUploader.promptEnhance",
         "title": "Context Engine Uploader: Prompt+ (Unicorn Mode)"
+      },
+      {
+        "command": "contextEngineUploader.promptEnhanceCopy",
+        "title": "Context Engine Uploader: Prompt+ (Copy to Clipboard)"
+      },
+      {
+        "command": "contextEngineUploader.promptEnhanceOpen",
+        "title": "Context Engine Uploader: Prompt+ (Open in New Editor)"
+      },
+      {
+        "command": "contextEngineUploader.setCtxDefaultMode",
+        "title": "Context Engine Uploader: Prompt+ Default Mode (ctx_config.json)"
       },
       {
         "command": "contextEngineUploader.authLogin",

--- a/vscode-extension/context-engine-uploader/prompt_plus.js
+++ b/vscode-extension/context-engine-uploader/prompt_plus.js
@@ -67,22 +67,99 @@ function createPromptPlusManager(deps) {
     return undefined;
   }
 
-  async function enhanceSelectionWithUnicorn() {
+  function getActiveSelectionText() {
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
-      vscode.window.showWarningMessage('Open a file and select text to enhance with Prompt+.');
-      return;
+      return { editor: undefined, selection: undefined, text: '' };
     }
     const selection = editor.selections && editor.selections.length ? editor.selections[0] : editor.selection;
     const text = selection && !selection.isEmpty ? editor.document.getText(selection) : '';
-    if (!text || !text.trim()) {
-      vscode.window.showWarningMessage('Select text to enhance with Prompt+.');
-      return;
+    return { editor, selection, text };
+  }
+
+  async function resolveInputTextFromUser(selectionText) {
+    const selectionTrimmed = (selectionText || '').trim();
+    if (selectionTrimmed) {
+      const picked = await vscode.window.showQuickPick(
+        [
+          { label: 'Use selection', id: 'selection' },
+          { label: 'Enter message', id: 'message' },
+          { label: 'Enter message + selection', id: 'message+selection' },
+        ],
+        { placeHolder: 'Prompt+ input source' }
+      );
+      if (!picked) {
+        return undefined;
+      }
+      if (picked.id === 'selection') {
+        return selectionText;
+      }
+      const message = await vscode.window.showInputBox({
+        prompt: 'Prompt+ message',
+        placeHolder: 'Type an instruction or question to enhance with Context Engine',
+        ignoreFocusOut: true,
+      });
+      const msgTrimmed = (message || '').trim();
+      if (!msgTrimmed) {
+        return undefined;
+      }
+      if (picked.id === 'message') {
+        return msgTrimmed;
+      }
+      return `${msgTrimmed}\n\n${selectionText}`;
     }
 
+    const message = await vscode.window.showInputBox({
+      prompt: 'Prompt+ message',
+      placeHolder: 'Type an instruction or question to enhance with Context Engine',
+      ignoreFocusOut: true,
+    });
+    const msgTrimmed = (message || '').trim();
+    if (!msgTrimmed) {
+      return undefined;
+    }
+    return msgTrimmed;
+  }
+
+  function normalizePromptMode(raw) {
+    const v = (raw || '').trim().toLowerCase();
+    if (v === 'unicorn') {
+      return 'unicorn';
+    }
+    return 'default';
+  }
+
+  function readDefaultModeFromCtxConfig(ctxWorkspaceDir) {
+    try {
+      if (!ctxWorkspaceDir || typeof ctxWorkspaceDir !== 'string') {
+        return undefined;
+      }
+      const cfgPath = path.join(ctxWorkspaceDir, 'ctx_config.json');
+      if (!fs.existsSync(cfgPath)) {
+        return undefined;
+      }
+      const raw = fs.readFileSync(cfgPath, 'utf8');
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object') {
+        return undefined;
+      }
+      if (typeof parsed.default_mode === 'string') {
+        return normalizePromptMode(parsed.default_mode);
+      }
+      return undefined;
+    } catch (_) {
+      return undefined;
+    }
+  }
+
+  function runPrompt(text) {
+    const input = (text || '').trim();
+    if (!input) {
+      return Promise.resolve(undefined);
+    }
     const ctxScript = resolveCtxScriptPath();
     if (!ctxScript) {
-      return;
+      return Promise.resolve(undefined);
     }
 
     const pythonPath = getConfiguredPythonPath();
@@ -111,16 +188,15 @@ function createPromptPlusManager(deps) {
         env.MCP_INDEXER_URL = idxUrlRaw;
       }
     } catch (_) {
-      // ignore config read failures; fall back to defaults
     }
 
+    let ctxWorkspaceDir;
     try {
       const cfg = getEffectiveConfig();
       const useGpuDecoder = cfg.get('useGpuDecoder', false);
       if (useGpuDecoder) {
         env.USE_GPU_DECODER = '1';
       }
-      let ctxWorkspaceDir;
       try {
         ctxWorkspaceDir = getTargetPath(cfg);
       } catch (error) {
@@ -136,16 +212,23 @@ function createPromptPlusManager(deps) {
         env.CTX_WORKSPACE_DIR = ctxWorkspaceDir;
       }
     } catch (_) {
-      // ignore config read failures; fall back to defaults
+      ctxWorkspaceDir = undefined;
     }
 
     const existingPyPath = env.PYTHONPATH || '';
     env.PYTHONPATH = existingPyPath ? `${projectRoot}${path.delimiter}${existingPyPath}` : projectRoot;
 
-    log(`Running Prompt+ via ctx.py at ${ctxScript}`);
+    const configuredMode = readDefaultModeFromCtxConfig(ctxWorkspaceDir);
+    const modeUsed = configuredMode || 'default';
+
+    log(`Running Prompt+ via ctx.py at ${ctxScript} (mode=${modeUsed})`);
 
     return new Promise((resolve) => {
-      const args = [ctxScript, '--unicorn', text];
+      const args = [ctxScript];
+      if (modeUsed === 'unicorn') {
+        args.push('--unicorn');
+      }
+      args.push(input);
       const child = spawn(pythonPath, args, { cwd: projectRoot, env });
       let stdout = '';
       let stderr = '';
@@ -164,7 +247,6 @@ function createPromptPlusManager(deps) {
               appendOutput(`[prompt+] ${chunk}`);
             }
           } catch (_) {
-            // ignore
           }
         });
       }
@@ -172,34 +254,82 @@ function createPromptPlusManager(deps) {
       child.on('error', error => {
         log(`Prompt+ spawn failed: ${error instanceof Error ? error.message : String(error)}`);
         vscode.window.showErrorMessage('Prompt+ failed to start. Check Python path.');
-        resolve();
+        resolve(undefined);
       });
 
       child.on('close', code => {
         if (code !== 0) {
           log(`Prompt+ exited with code ${code}${stderr ? `: ${stderr.trim()}` : ''}`);
           vscode.window.showErrorMessage('Prompt+ failed. See output for details.');
-          return resolve();
+          return resolve(undefined);
         }
         const enhanced = (stdout || '').trim();
         if (!enhanced) {
           vscode.window.showWarningMessage('Prompt+ returned no output.');
-          return resolve();
+          return resolve(undefined);
         }
-        editor.edit(editBuilder => editBuilder.replace(selection, enhanced)).then(ok => {
-          if (ok) {
-            vscode.window.showInformationMessage('Prompt+ applied (Unicorn Mode).');
-          } else {
-            vscode.window.showErrorMessage('Prompt+ could not update the selection.');
-          }
-          resolve();
-        });
+        resolve({ enhanced, modeUsed });
       });
     });
   }
 
+  async function enhanceSelectionWithUnicorn() {
+    const { editor, selection, text } = getActiveSelectionText();
+    if (!editor) {
+      vscode.window.showWarningMessage('Open a file and select text to enhance with Prompt+.');
+      return;
+    }
+    if (!selection || selection.isEmpty || !text || !text.trim()) {
+      vscode.window.showWarningMessage('Select text to enhance with Prompt+.');
+      return;
+    }
+    const result = await runPrompt(text);
+    if (!result || !result.enhanced) {
+      return;
+    }
+    const modeLabel = result.modeUsed === 'unicorn' ? 'Unicorn Mode' : 'Default Mode';
+    await editor.edit(editBuilder => editBuilder.replace(selection, result.enhanced)).then(ok => {
+      if (ok) {
+        vscode.window.showInformationMessage(`Prompt+ applied (${modeLabel}).`);
+      } else {
+        vscode.window.showErrorMessage('Prompt+ could not update the selection.');
+      }
+    });
+  }
+
+  async function enhancePromptWithUnicornCopy() {
+    const { text } = getActiveSelectionText();
+    const input = await resolveInputTextFromUser(text);
+    if (!input) {
+      return;
+    }
+    const result = await runPrompt(input);
+    if (!result || !result.enhanced) {
+      return;
+    }
+    const modeLabel = result.modeUsed === 'unicorn' ? 'Unicorn Mode' : 'Default Mode';
+    await vscode.env.clipboard.writeText(result.enhanced);
+    vscode.window.showInformationMessage(`Prompt+ copied to clipboard (${modeLabel}).`);
+  }
+
+  async function enhancePromptWithUnicornOpen() {
+    const { text } = getActiveSelectionText();
+    const input = await resolveInputTextFromUser(text);
+    if (!input) {
+      return;
+    }
+    const result = await runPrompt(input);
+    if (!result || !result.enhanced) {
+      return;
+    }
+    const doc = await vscode.workspace.openTextDocument({ content: result.enhanced, language: 'markdown' });
+    await vscode.window.showTextDocument(doc, { preview: true });
+  }
+
   return {
     enhanceSelectionWithUnicorn,
+    enhancePromptWithUnicornCopy,
+    enhancePromptWithUnicornOpen,
     dispose,
   };
 }

--- a/vscode-extension/context-engine-uploader/prompt_plus_commands.js
+++ b/vscode-extension/context-engine-uploader/prompt_plus_commands.js
@@ -1,0 +1,169 @@
+function registerPromptPlusCommands(deps) {
+  const vscode = deps.vscode;
+  const fs = deps.fs;
+  const path = deps.path;
+  const log = deps.log;
+
+  const getEffectiveConfig = deps.getEffectiveConfig;
+  const resolveTargetPathFromConfig = deps.resolveTargetPathFromConfig;
+  const writeCtxConfig = deps.writeCtxConfig;
+  const getPromptPlusManager = deps.getPromptPlusManager;
+  const getSidebarApi = deps.getSidebarApi;
+
+  const promptEnhanceDisposable = vscode.commands.registerCommand('contextEngineUploader.promptEnhance', () => {
+    try {
+      const promptPlusManager = typeof getPromptPlusManager === 'function' ? getPromptPlusManager() : undefined;
+      if (promptPlusManager && typeof promptPlusManager.enhanceSelectionWithUnicorn === 'function') {
+        promptPlusManager.enhanceSelectionWithUnicorn().catch(error => {
+          log(`Prompt+ failed: ${error instanceof Error ? error.message : String(error)}`);
+          vscode.window.showErrorMessage('Prompt+ failed. See Context Engine Upload output.');
+        });
+      } else {
+        vscode.window.showErrorMessage('Context Engine Uploader: Prompt+ is unavailable (extension failed to initialize Prompt+ manager). See output for details.');
+      }
+    } catch (error) {
+      log(`Prompt+ failed: ${error instanceof Error ? error.message : String(error)}`);
+      vscode.window.showErrorMessage('Prompt+ failed. See Context Engine Upload output.');
+    }
+  });
+
+  const promptEnhanceCopyDisposable = vscode.commands.registerCommand('contextEngineUploader.promptEnhanceCopy', () => {
+    try {
+      const promptPlusManager = typeof getPromptPlusManager === 'function' ? getPromptPlusManager() : undefined;
+      if (promptPlusManager && typeof promptPlusManager.enhancePromptWithUnicornCopy === 'function') {
+        promptPlusManager.enhancePromptWithUnicornCopy().catch(error => {
+          log(`Prompt+ copy failed: ${error instanceof Error ? error.message : String(error)}`);
+          vscode.window.showErrorMessage('Prompt+ copy failed. See Context Engine Upload output.');
+        });
+      } else {
+        vscode.window.showErrorMessage('Context Engine Uploader: Prompt+ is unavailable (extension failed to initialize Prompt+ manager). See output for details.');
+      }
+    } catch (error) {
+      log(`Prompt+ copy failed: ${error instanceof Error ? error.message : String(error)}`);
+      vscode.window.showErrorMessage('Prompt+ copy failed. See Context Engine Upload output.');
+    }
+  });
+
+  const promptEnhanceOpenDisposable = vscode.commands.registerCommand('contextEngineUploader.promptEnhanceOpen', () => {
+    try {
+      const promptPlusManager = typeof getPromptPlusManager === 'function' ? getPromptPlusManager() : undefined;
+      if (promptPlusManager && typeof promptPlusManager.enhancePromptWithUnicornOpen === 'function') {
+        promptPlusManager.enhancePromptWithUnicornOpen().catch(error => {
+          log(`Prompt+ open failed: ${error instanceof Error ? error.message : String(error)}`);
+          vscode.window.showErrorMessage('Prompt+ open failed. See Context Engine Upload output.');
+        });
+      } else {
+        vscode.window.showErrorMessage('Context Engine Uploader: Prompt+ is unavailable (extension failed to initialize Prompt+ manager). See output for details.');
+      }
+    } catch (error) {
+      log(`Prompt+ open failed: ${error instanceof Error ? error.message : String(error)}`);
+      vscode.window.showErrorMessage('Prompt+ open failed. See Context Engine Upload output.');
+    }
+  });
+
+  const promptDefaultModeDisposable = vscode.commands.registerCommand('contextEngineUploader.setCtxDefaultMode', async () => {
+    const cfg = getEffectiveConfig();
+    const resolved = resolveTargetPathFromConfig(cfg);
+    const targetPath = resolved && resolved.path ? String(resolved.path).trim() : '';
+    if (!targetPath) {
+      vscode.window.showErrorMessage('Context Engine Uploader: targetPath is not configured (cannot locate ctx_config.json).');
+      return;
+    }
+
+    const ctxConfigPath = path.join(targetPath, 'ctx_config.json');
+    const items = [
+      {
+        label: 'default',
+        description: 'Fast single-pass rewrite (ctx.py default)',
+        value: 'default',
+      },
+      {
+        label: 'unicorn',
+        description: 'Best quality multi-pass rewrite (ctx.py --unicorn)',
+        value: 'unicorn',
+      },
+    ];
+
+    let existing = {};
+    if (fs.existsSync(ctxConfigPath)) {
+      try {
+        const raw = fs.readFileSync(ctxConfigPath, 'utf8');
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object') {
+          existing = parsed;
+        }
+      } catch (error) {
+        log(`Failed to parse ctx_config.json at ${ctxConfigPath}: ${error instanceof Error ? error.message : String(error)}`);
+        vscode.window.showErrorMessage('Context Engine Uploader: failed to parse ctx_config.json. See output for details.');
+        return;
+      }
+    } else {
+      const pickedInit = await vscode.window.showInformationMessage(
+        'ctx_config.json not found. Create it now?',
+        'Create',
+        'Cancel'
+      );
+      if (pickedInit !== 'Create') {
+        return;
+      }
+      await writeCtxConfig();
+      if (!fs.existsSync(ctxConfigPath)) {
+        vscode.window.showErrorMessage('Context Engine Uploader: ctx_config.json is still missing after scaffolding.');
+        return;
+      }
+      try {
+        const raw = fs.readFileSync(ctxConfigPath, 'utf8');
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object') {
+          existing = parsed;
+        }
+      } catch (error) {
+        log(`Failed to parse ctx_config.json after scaffolding at ${ctxConfigPath}: ${error instanceof Error ? error.message : String(error)}`);
+        vscode.window.showErrorMessage('Context Engine Uploader: failed to parse ctx_config.json after scaffolding. See output for details.');
+        return;
+      }
+    }
+
+    const currentMode = (typeof existing.default_mode === 'string' ? existing.default_mode.trim() : '') || 'default';
+    const picked = await vscode.window.showQuickPick(items, {
+      placeHolder: `Prompt+ default mode (currently: ${currentMode})`,
+      matchOnDescription: true,
+      ignoreFocusOut: true,
+    });
+    if (!picked) {
+      return;
+    }
+
+    if (picked.value === currentMode) {
+      vscode.window.showInformationMessage(`Prompt+ default mode already set to '${currentMode}'.`);
+      return;
+    }
+
+    try {
+      existing.default_mode = picked.value;
+      fs.writeFileSync(ctxConfigPath, JSON.stringify(existing, null, 2) + '\n', 'utf8');
+      vscode.window.showInformationMessage(`Prompt+ default mode set to '${picked.value}'.`);
+      try {
+        const sidebarApi = typeof getSidebarApi === 'function' ? getSidebarApi() : undefined;
+        if (sidebarApi && typeof sidebarApi.refresh === 'function') {
+          sidebarApi.refresh();
+        }
+      } catch (_) {
+      }
+    } catch (error) {
+      log(`Failed to write ctx_config.json default_mode at ${ctxConfigPath}: ${error instanceof Error ? error.message : String(error)}`);
+      vscode.window.showErrorMessage('Context Engine Uploader: failed to update ctx_config.json. See output for details.');
+    }
+  });
+
+  return [
+    promptEnhanceDisposable,
+    promptEnhanceCopyDisposable,
+    promptEnhanceOpenDisposable,
+    promptDefaultModeDisposable,
+  ];
+}
+
+module.exports = {
+  registerPromptPlusCommands,
+};

--- a/vscode-extension/context-engine-uploader/sidebar.js
+++ b/vscode-extension/context-engine-uploader/sidebar.js
@@ -423,6 +423,18 @@ function register(context, deps) {
       }
 
       items.push(
+        makeTreeItem('Read Docs', {
+          icon: new vscode.ThemeIcon('book'),
+          command: {
+            command: 'vscode.open',
+            title: 'Open Context Engine Docs',
+            arguments: [vscode.Uri.parse('https://github.com/m1rl0k/Context-Engine/blob/test/docs/GETTING_STARTED.md')],
+          },
+          tooltip: 'Open the Context Engine documentation in your browser.',
+        })
+      );
+
+      items.push(
         makeTreeItem('Open Settings', {
           icon: new vscode.ThemeIcon('gear'),
           command: { command: 'workbench.action.openSettings', title: 'Open Settings', arguments: ['contextEngineUploader'] },

--- a/vscode-extension/context-engine-uploader/sidebar.js
+++ b/vscode-extension/context-engine-uploader/sidebar.js
@@ -551,7 +551,10 @@ function register(context, deps) {
       const showAuth = !!(bridgeMode && endpoint && endpointReachable !== false && (authEnabled === true || authEnabled === undefined));
 
       const items = [
-        makeTreeItem('Prompt+', { icon: new vscode.ThemeIcon('sparkle'), command: { command: 'contextEngineUploader.promptEnhance', title: 'Prompt+' } }),
+        makeTreeItem('Prompt+ (Replace Selection)', { icon: new vscode.ThemeIcon('sparkle'), command: { command: 'contextEngineUploader.promptEnhance', title: 'Prompt+ (Replace Selection)' } }),
+        makeTreeItem('Prompt+ (Copy to Clipboard)', { icon: new vscode.ThemeIcon('copy'), command: { command: 'contextEngineUploader.promptEnhanceCopy', title: 'Prompt+ (Copy to Clipboard)' } }),
+        makeTreeItem('Prompt+ (Open in New Editor)', { icon: new vscode.ThemeIcon('open-preview'), command: { command: 'contextEngineUploader.promptEnhanceOpen', title: 'Prompt+ (Open in New Editor)' } }),
+        makeTreeItem('Prompt+ Default Mode...', { icon: new vscode.ThemeIcon('settings-gear'), command: { command: 'contextEngineUploader.setCtxDefaultMode', title: 'Prompt+ Default Mode' } }),
       ];
 
       if (showAuth) {


### PR DESCRIPTION
- Add Prompt+ actions in sidebar Utilities: replace, copy, open
- Add “Prompt+ Default Mode…” QuickPick to persist ctx_config.json default_mode
- Make Prompt+ runner respect ctx_config.json default_mode and show correct mode in toasts
- Modularize Prompt+ command registration into prompt_plus_commands.js
- Add read docs link in getting started section
<img width="524" height="160" alt="image" src="https://github.com/user-attachments/assets/71c2322e-2480-4a67-aea6-2998160b11ca" />
