### PR TITLE
feat: add admin indexing helper and surface indexing progress

### DIFF
--- a/scripts/indexing_admin.py
+++ b/scripts/indexing_admin.py
@@ -1,0 +1,238 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+try:
+    from qdrant_client import QdrantClient
+except Exception:
+    QdrantClient = None  # type: ignore
+
+try:
+    from scripts.workspace_state import (
+        get_collection_mappings,
+        get_workspace_state,
+        update_indexing_status,
+        get_indexing_config_snapshot,
+        compute_indexing_config_hash,
+    )
+except Exception:
+    get_collection_mappings = None  # type: ignore
+    get_workspace_state = None  # type: ignore
+    update_indexing_status = None  # type: ignore
+    get_indexing_config_snapshot = None  # type: ignore
+    compute_indexing_config_hash = None  # type: ignore
+
+
+def current_env_indexing_hash() -> str:
+    try:
+        if get_indexing_config_snapshot and compute_indexing_config_hash:
+            return compute_indexing_config_hash(get_indexing_config_snapshot())
+    except Exception:
+        return ""
+    return ""
+
+
+def collection_mapping_index(*, work_dir: str) -> Dict[str, List[Dict[str, Any]]]:
+    if not get_collection_mappings:
+        return {}
+    try:
+        mappings = get_collection_mappings(search_root=work_dir) or []
+    except Exception:
+        mappings = []
+    out: Dict[str, List[Dict[str, Any]]] = {}
+    for m in mappings:
+        try:
+            name = str(m.get("collection_name") or "").strip()
+        except Exception:
+            name = ""
+        if not name:
+            continue
+        out.setdefault(name, []).append(m)
+    return out
+
+
+def resolve_collection_root(*, collection: str, work_dir: str) -> Tuple[Optional[str], Optional[str]]:
+    name = (collection or "").strip()
+    if not name:
+        return None, None
+    idx = collection_mapping_index(work_dir=work_dir)
+    candidates = idx.get(name) or []
+    if not candidates:
+        return None, None
+    chosen = candidates[0]
+    repo_name = chosen.get("repo_name")
+    container_path = chosen.get("container_path")
+    try:
+        repo_name = str(repo_name) if repo_name is not None else None
+    except Exception:
+        repo_name = None
+    try:
+        container_path = str(container_path) if container_path is not None else None
+    except Exception:
+        container_path = None
+    if container_path:
+        return container_path, repo_name
+    return work_dir, repo_name
+
+
+def get_indexing_state(*, workspace_path: str, repo_name: Optional[str]) -> str:
+    if not get_workspace_state:
+        return ""
+    try:
+        st = get_workspace_state(workspace_path, repo_name) or {}
+        idx_status = st.get("indexing_status") or {}
+        if isinstance(idx_status, dict):
+            return str(idx_status.get("state") or "")
+    except Exception:
+        return ""
+    return ""
+
+
+def build_admin_collections_view(*, collections: Any, work_dir: str) -> List[Dict[str, Any]]:
+    env_hash = current_env_indexing_hash()
+    mapping_index = collection_mapping_index(work_dir=work_dir)
+
+    enriched: List[Dict[str, Any]] = []
+    for c in collections or []:
+        try:
+            coll_name = str(getattr(c, "qdrant_collection", None) or c.get("qdrant_collection") or "").strip()  # type: ignore[union-attr]
+        except Exception:
+            coll_name = ""
+
+        applied_hash = ""
+        indexing_state = ""
+        indexing_started_at = ""
+        progress_files_processed: Optional[int] = None
+        progress_total_files: Optional[int] = None
+        progress_current_file = ""
+        repo_name = None
+        container_path = None
+        mapping_count = 0
+
+        try:
+            matches = mapping_index.get(coll_name) or []
+            mapping_count = len(matches)
+            if matches:
+                m = matches[0]
+                repo_name = m.get("repo_name")
+                container_path = m.get("container_path")
+        except Exception:
+            mapping_count = 0
+
+        if container_path and get_workspace_state:
+            try:
+                st = get_workspace_state(str(container_path), repo_name) or {}
+                applied_hash = str(st.get("indexing_config_hash") or "")
+                idx_status = st.get("indexing_status") or {}
+                if isinstance(idx_status, dict):
+                    indexing_state = str(idx_status.get("state") or "")
+                    indexing_started_at = str(idx_status.get("started_at") or "")
+                    progress = idx_status.get("progress") or {}
+                    if isinstance(progress, dict):
+                        try:
+                            progress_files_processed = int(progress.get("files_processed"))
+                        except Exception:
+                            progress_files_processed = None
+                        try:
+                            progress_total_files = int(progress.get("total_files"))
+                        except Exception:
+                            progress_total_files = None
+                        try:
+                            progress_current_file = str(progress.get("current_file") or "")
+                        except Exception:
+                            progress_current_file = ""
+            except Exception:
+                applied_hash = ""
+                indexing_state = ""
+                indexing_started_at = ""
+                progress_files_processed = None
+                progress_total_files = None
+                progress_current_file = ""
+
+        needs_reindex = bool(env_hash and applied_hash and env_hash != applied_hash)
+
+        try:
+            cid = getattr(c, "id", None) if hasattr(c, "id") else c.get("id")  # type: ignore[union-attr]
+        except Exception:
+            cid = None
+
+        enriched.append(
+            {
+                "id": cid,
+                "qdrant_collection": coll_name,
+                "container_path": str(container_path) if container_path else "",
+                "repo_name": str(repo_name) if repo_name else "",
+                "mapping_count": mapping_count,
+                "indexing_state": indexing_state,
+                "indexing_started_at": indexing_started_at,
+                "progress_files_processed": progress_files_processed,
+                "progress_total_files": progress_total_files,
+                "progress_current_file": progress_current_file,
+                "applied_indexing_hash": applied_hash,
+                "current_indexing_hash": env_hash,
+                "needs_reindex": needs_reindex,
+                "has_mapping": bool(container_path),
+            }
+        )
+
+    return enriched
+
+
+def recreate_collection_qdrant(*, qdrant_url: str, api_key: Optional[str], collection: str) -> None:
+    if QdrantClient is None:
+        return
+    name = (collection or "").strip()
+    if not name:
+        return
+    try:
+        cli = QdrantClient(url=qdrant_url, api_key=api_key or None)
+    except Exception:
+        return
+    try:
+        try:
+            cli.delete_collection(collection_name=name)
+        except Exception:
+            pass
+    finally:
+        try:
+            cli.close()
+        except Exception:
+            pass
+
+
+def spawn_ingest_code(
+    *,
+    root: str,
+    work_dir: str,
+    collection: str,
+    recreate: bool,
+    repo_name: Optional[str],
+) -> None:
+    script_path = str((Path(__file__).resolve().parent / "ingest_code.py").resolve())
+    cmd = [sys.executable or "python3", script_path, "--root", root, "--no-skip-unchanged"]
+    if recreate:
+        cmd.append("--recreate")
+
+    env = os.environ.copy()
+    env["COLLECTION_NAME"] = collection
+    env["WATCH_ROOT"] = work_dir
+    env["WORKSPACE_PATH"] = work_dir
+
+    try:
+        if update_indexing_status:
+            update_indexing_status(
+                workspace_path=root,
+                repo_name=repo_name,
+                status={
+                    "state": "initializing",
+                    "started_at": datetime.now().isoformat(),
+                    "progress": {"files_processed": 0, "total_files": None, "current_file": None},
+                },
+            )
+    except Exception:
+        pass
+
+    subprocess.Popen(cmd, env=env)

--- a/scripts/upload_service.py
+++ b/scripts/upload_service.py
@@ -597,6 +597,20 @@ async def admin_acl_grant(
     return RedirectResponse(url="/admin/acl", status_code=302)
 
 
+@app.get("/admin/collections/status")
+async def admin_collections_status(request: Request):
+    _require_admin_session(request)
+    try:
+        collections = list_collections(include_deleted=False)
+    except AuthDisabledError:
+        raise HTTPException(status_code=404, detail="Auth disabled")
+    except Exception:
+        raise HTTPException(status_code=500, detail="Failed to load collections")
+
+    enriched = build_admin_collections_view(collections=collections, work_dir=WORK_DIR)
+    return JSONResponse({"collections": enriched})
+
+
 @app.post("/admin/collections/reindex")
 async def admin_reindex_collection(
     request: Request,

--- a/templates/admin/acl.html
+++ b/templates/admin/acl.html
@@ -48,15 +48,71 @@
     {% endif %}
 
     <table>
-      <tr><th>id</th><th>qdrant_collection</th><th></th></tr>
+      <tr>
+        <th>id</th>
+        <th>qdrant_collection</th>
+        <th>indexing_status</th>
+        <th>mapping</th>
+        <th>applied_hash</th>
+        <th>current_hash</th>
+        <th>actions</th>
+      </tr>
       {% if collections and collections|length > 0 %}
         {% for c in collections %}
-          <tr>
+          <tr {% if c.needs_reindex %}style="background:#fff3cd"{% endif %}>
             <td>{{ c.id }}</td>
-            <td>{{ c.qdrant_collection }}</td>
             <td>
+              <div>{{ c.qdrant_collection }}</div>
+              {% if c.container_path %}
+                <div class="muted">{{ c.container_path }}</div>
+              {% endif %}
+              {% if c.repo_name %}
+                <div class="muted">repo: {{ c.repo_name }}</div>
+              {% endif %}
+            </td>
+            <td>
+              <div>{{ c.indexing_state or "idle" }}</div>
+              {% if c.indexing_started_at %}
+                <div class="muted">started {{ c.indexing_started_at }}</div>
+              {% endif %}
+              {% if c.progress_files_processed is not none %}
+                <div class="muted">
+                  {{ c.progress_files_processed }}
+                  {% if c.progress_total_files %}
+                    / {{ c.progress_total_files }}
+                  {% endif %}
+                  files
+                </div>
+              {% endif %}
+              {% if c.progress_current_file %}
+                <div class="muted small">{{ c.progress_current_file }}</div>
+              {% endif %}
+            </td>
+            <td>
+              {% if c.has_mapping %}
+                <span class="muted">ok ({{ c.mapping_count }})</span>
+              {% else %}
+                <span class="error">missing</span>
+              {% endif %}
+              {% if c.needs_reindex %}
+                <div class="error">maintenance needed</div>
+              {% endif %}
+            </td>
+            <td><span class="muted">{{ c.applied_indexing_hash }}</span></td>
+            <td><span class="muted">{{ c.current_indexing_hash }}</span></td>
+            <td>
+              {% if c.has_mapping %}
+                <form class="inline" method="post" action="/admin/collections/reindex" onsubmit="return confirm('Reindex collection ' + '{{ c.qdrant_collection }}' + '?');">
+                  <input type="hidden" name="collection" value="{{ c.qdrant_collection }}" />
+                  <button type="submit">Reindex</button>
+                </form>
+                <form class="inline" method="post" action="/admin/collections/recreate" onsubmit="return confirm('Recreate collection ' + '{{ c.qdrant_collection }}' + '? This will recreate Qdrant collection and reindex all files.');">
+                  <input type="hidden" name="collection" value="{{ c.qdrant_collection }}" />
+                  <button type="submit">Recreate</button>
+                </form>
+              {% endif %}
               {% if deletion_enabled %}
-                <form method="post" action="/admin/collections/delete" onsubmit="return confirm('Delete collection ' + '{{ c.qdrant_collection }}' + '? This may delete server-side files under {{ work_dir }} if filesystem cleanup is selected.');">
+                <form class="inline" method="post" action="/admin/collections/delete" onsubmit="return confirm('Delete collection ' + '{{ c.qdrant_collection }}' + '? This may delete server-side files under {{ work_dir }} if filesystem cleanup is selected.');">
                   <input type="hidden" name="collection" value="{{ c.qdrant_collection }}" />
                   <label class="muted" style="display:block; margin-bottom:6px;">
                     <input type="checkbox" name="delete_fs" value="1" />
@@ -69,7 +125,7 @@
           </tr>
         {% endfor %}
       {% else %}
-        <tr><td colspan="3">(none)</td></tr>
+        <tr><td colspan="7">(none)</td></tr>
       {% endif %}
     </table>
   </div>

--- a/templates/admin/acl.html
+++ b/templates/admin/acl.html
@@ -47,16 +47,19 @@
       <p class="muted">Collection deletion is disabled by server configuration.</p>
     {% endif %}
 
-    <table>
-      <tr>
-        <th>id</th>
-        <th>qdrant_collection</th>
-        <th>indexing_status</th>
-        <th>mapping</th>
-        <th>applied_hash</th>
-        <th>current_hash</th>
-        <th>actions</th>
-      </tr>
+    <table id="collections-table" data-deletion-enabled="{{ '1' if deletion_enabled else '0' }}" data-work-dir="{{ work_dir }}">
+      <thead>
+        <tr>
+          <th>id</th>
+          <th>qdrant_collection</th>
+          <th>indexing_status</th>
+          <th>mapping</th>
+          <th>applied_hash</th>
+          <th>current_hash</th>
+          <th>actions</th>
+        </tr>
+      </thead>
+      <tbody id="collections-body">
       {% if collections and collections|length > 0 %}
         {% for c in collections %}
           <tr {% if c.needs_reindex %}style="background:#fff3cd"{% endif %}>
@@ -127,6 +130,7 @@
       {% else %}
         <tr><td colspan="7">(none)</td></tr>
       {% endif %}
+      </tbody>
     </table>
   </div>
 
@@ -184,4 +188,134 @@
 
     <p class="muted">Collection permissions are enforced by MCP servers when CTXCE_MCP_ACL_ENFORCE=1 (and CTXCE_ACL_ALLOW_ALL=0).</p>
   </div>
+  <script>
+    (function () {
+      const REFRESH_MS = 5000;
+      const bodyEl = document.getElementById("collections-body");
+      const tableEl = document.getElementById("collections-table");
+      if (!bodyEl) {
+        return;
+      }
+      const deletionEnabled =
+        tableEl && tableEl.dataset && tableEl.dataset.deletionEnabled === "1";
+      const workDir = (tableEl && tableEl.dataset && tableEl.dataset.workDir) || "";
+
+      function escapeHtml(str) {
+        return str
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;")
+          .replace(/'/g, "&#39;");
+      }
+
+      function safeValue(val) {
+        return val === null || val === undefined ? "" : val;
+      }
+
+      function renderRow(c) {
+        const highlight = c.needs_reindex ? ' style="background:#fff3cd"' : "";
+        const containerInfo = c.container_path
+          ? `<div class="muted">${escapeHtml(c.container_path)}</div>`
+          : "";
+        const repoInfo = c.repo_name ? `<div class="muted">repo: ${escapeHtml(c.repo_name)}</div>` : "";
+        const mappingInfo = c.has_mapping
+          ? `<span class="muted">ok (${c.mapping_count})</span>`
+          : '<span class="error">missing</span>';
+        const maintenance = c.needs_reindex ? '<div class="error">maintenance needed</div>' : "";
+        const started = c.indexing_started_at
+          ? `<div class="muted">started ${escapeHtml(c.indexing_started_at)}</div>`
+          : "";
+        const filesProcessed =
+          c.progress_files_processed !== null && c.progress_files_processed !== undefined
+            ? `<div class="muted">${c.progress_files_processed}${
+                c.progress_total_files ? ` / ${c.progress_total_files}` : ""
+              } files</div>`
+            : "";
+        const currentFile = c.progress_current_file
+          ? `<div class="muted small">${escapeHtml(c.progress_current_file)}</div>`
+          : "";
+        const actions = c.has_mapping
+          ? `
+            <form class="inline" method="post" action="/admin/collections/reindex" onsubmit="return confirm('Reindex collection ${escapeHtml(
+              c.qdrant_collection
+            )}?');">
+              <input type="hidden" name="collection" value="${escapeHtml(c.qdrant_collection)}" />
+              <button type="submit">Reindex</button>
+            </form>
+            <form class="inline" method="post" action="/admin/collections/recreate" onsubmit="return confirm('Recreate collection ${escapeHtml(
+              c.qdrant_collection
+            )}? This will recreate Qdrant collection and reindex all files.');">
+              <input type="hidden" name="collection" value="${escapeHtml(c.qdrant_collection)}" />
+              <button type="submit">Recreate</button>
+            </form>
+          `
+          : "";
+        const deleteHtml = deletionEnabled
+          ? `
+            <form class="inline" method="post" action="/admin/collections/delete" onsubmit="return confirm('Delete collection ${escapeHtml(
+              c.qdrant_collection
+            )}? This may delete server-side files under ${escapeHtml(workDir)} if filesystem cleanup is selected.');">
+              <input type="hidden" name="collection" value="${escapeHtml(c.qdrant_collection)}" />
+              <label class="muted" style="display:block; margin-bottom:6px;">
+                <input type="checkbox" name="delete_fs" value="1" />
+                Also delete filesystem (dangerous)
+              </label>
+              <button type="submit">Delete</button>
+            </form>
+          `
+          : "";
+
+        return `
+          <tr${highlight}>
+            <td>${escapeHtml(String(safeValue(c.id)))}</td>
+            <td>
+              <div>${escapeHtml(c.qdrant_collection || "")}</div>
+              ${containerInfo}
+              ${repoInfo}
+            </td>
+            <td>
+              <div>${escapeHtml(c.indexing_state || "idle")}</div>
+              ${started}
+              ${filesProcessed}
+              ${currentFile}
+            </td>
+            <td>
+              ${mappingInfo}
+              ${maintenance}
+            </td>
+            <td><span class="muted">${escapeHtml(c.applied_indexing_hash || "")}</span></td>
+            <td><span class="muted">${escapeHtml(c.current_indexing_hash || "")}</span></td>
+            <td>
+              ${actions}
+              ${deleteHtml}
+            </td>
+          </tr>
+        `;
+      }
+
+      async function refreshCollections() {
+        try {
+          const resp = await fetch("/admin/collections/status", { headers: { "X-Requested-With": "fetch" } });
+          if (!resp.ok) {
+            throw new Error("Failed to load status");
+          }
+          const data = await resp.json();
+          if (!data || !Array.isArray(data.collections)) {
+            return;
+          }
+          if (data.collections.length === 0) {
+            bodyEl.innerHTML = '<tr><td colspan="7">(none)</td></tr>';
+            return;
+          }
+          bodyEl.innerHTML = data.collections.map(renderRow).join("");
+        } catch (err) {
+          console.warn("Failed to refresh collections", err);
+        }
+      }
+
+      refreshCollections();
+      setInterval(refreshCollections, REFRESH_MS);
+    })();
+  </script>
 {% endblock %}


### PR DESCRIPTION
Added scripts/indexing_admin.py to centralize collection resolution, env hash detection, Qdrant recreate, progress extraction, and non-blocking ingest_code spawns

Persisted additional embedding/mini-vector flags in the workspace indexing snapshot, wiring the watcher to update the snapshot in both single- and multi-repo flows

Enhanced the admin collections view to show live indexing status/metrics pulled from state.json and kept the reindex/recreate endpoints slim wrappers around the helper