### PR TITLE
Add workspace state as source for collection name

### DIFF
--- a/scripts/hybrid_search.py
+++ b/scripts/hybrid_search.py
@@ -111,7 +111,7 @@ logger = logging.getLogger("hybrid_search")
 
 
 def _collection(collection_name: str | None = None) -> str:
-    """Determine collection name with priority: CLI arg > env > default."""
+    """Determine collection name with priority: CLI arg > env > workspace state > default."""
 
     if collection_name and collection_name.strip():
         return collection_name.strip()
@@ -119,6 +119,15 @@ def _collection(collection_name: str | None = None) -> str:
     env_coll = os.environ.get("COLLECTION_NAME", "").strip()
     if env_coll:
         return env_coll
+
+    # Check workspace state (consistent with mcp_indexer_server)
+    try:
+        from scripts.workspace_state import get_collection_name
+        ws_coll = get_collection_name()
+        if ws_coll:
+            return ws_coll
+    except Exception:
+        pass
 
     return "my-collection"
 

--- a/scripts/hybrid_search.py
+++ b/scripts/hybrid_search.py
@@ -134,7 +134,7 @@ def _collection(collection_name: str | None = None) -> str:
     except Exception:
         pass
 
-    return "my-collection"
+    return "codebase"
 
 
 MODEL_NAME = os.environ.get("EMBEDDING_MODEL", "BAAI/bge-base-en-v1.5")

--- a/scripts/hybrid_search.py
+++ b/scripts/hybrid_search.py
@@ -123,7 +123,9 @@ def _collection(collection_name: str | None = None) -> str:
     # Read persisted qdrant_collection from .codebase/state.json (consistent with mcp_indexer_server)
     try:
         import json
-        state_file = Path("/work/.codebase/state.json")
+        # Use WORKSPACE_PATH / WATCH_ROOT env vars, fallback to /work for Docker compatibility
+        workspace_root = Path(os.environ.get("WORKSPACE_PATH") or os.environ.get("WATCH_ROOT") or "/work")
+        state_file = workspace_root / ".codebase" / "state.json"
         if state_file.exists():
             with open(state_file, "r", encoding="utf-8") as f:
                 state = json.load(f)

--- a/scripts/hybrid_search.py
+++ b/scripts/hybrid_search.py
@@ -120,12 +120,17 @@ def _collection(collection_name: str | None = None) -> str:
     if env_coll:
         return env_coll
 
-    # Check workspace state (consistent with mcp_indexer_server)
+    # Read persisted qdrant_collection from .codebase/state.json (consistent with mcp_indexer_server)
     try:
-        from scripts.workspace_state import get_collection_name
-        ws_coll = get_collection_name()
-        if ws_coll:
-            return ws_coll
+        import json
+        state_file = Path("/work/.codebase/state.json")
+        if state_file.exists():
+            with open(state_file, "r", encoding="utf-8") as f:
+                state = json.load(f)
+            if isinstance(state, dict):
+                coll = state.get("qdrant_collection")
+                if isinstance(coll, str) and coll.strip():
+                    return coll.strip()
     except Exception:
         pass
 

--- a/scripts/ingest_code.py
+++ b/scripts/ingest_code.py
@@ -238,6 +238,7 @@ def _use_tree_sitter() -> bool:
 
 
 CODE_EXTS = {
+    # Core languages
     ".py": "python",
     ".js": "javascript",
     ".ts": "typescript",
@@ -254,29 +255,64 @@ CODE_EXTS = {
     ".cc": "cpp",
     ".hpp": "cpp",
     ".cs": "csharp",
+    ".csx": "csharp",
     ".kt": "kotlin",
     ".swift": "swift",
     ".scala": "scala",
+    # Shell/scripting
     ".sh": "shell",
     ".ps1": "powershell",
     ".psm1": "powershell",
     ".psd1": "powershell",
+    ".pl": "perl",
+    ".lua": "lua",
+    # Data/config
     ".sql": "sql",
     ".md": "markdown",
     ".yml": "yaml",
     ".yaml": "yaml",
     ".toml": "toml",
     ".ini": "ini",
+    ".cfg": "ini",
+    ".conf": "ini",
     ".json": "json",
-    ".tf": "terraform",
-    ".hcl": "hcl",
-    ".csx": "csharp",
-    ".cshtml": "razor",
-    ".razor": "razor",
+    ".xml": "xml",
     ".csproj": "xml",
     ".config": "xml",
     ".resx": "xml",
+    # Web
+    ".html": "html",
+    ".htm": "html",
+    ".css": "css",
+    ".scss": "scss",
+    ".sass": "sass",
+    ".less": "less",
+    ".vue": "vue",
+    ".svelte": "svelte",
+    ".cshtml": "razor",
+    ".razor": "razor",
+    # Infrastructure
+    ".tf": "terraform",
+    ".tfvars": "terraform",
+    ".hcl": "hcl",
     ".dockerfile": "dockerfile",
+    # Additional languages
+    ".elm": "elm",
+    ".dart": "dart",
+    ".r": "r",
+    ".R": "r",
+    ".m": "matlab",
+    ".cljs": "clojure",
+    ".clj": "clojure",
+    ".hs": "haskell",
+    ".ml": "ocaml",
+    ".zig": "zig",
+    ".nim": "nim",
+    ".v": "verilog",
+    ".sv": "verilog",
+    ".vhdl": "vhdl",
+    ".asm": "assembly",
+    ".s": "assembly",
 }
 
 # Files matched by name (no extension or special names)
@@ -655,8 +691,11 @@ class _Excluder:
         return False
 
 
-def _is_indexable_file(p: Path) -> bool:
-    """Check if a file should be indexed (by extension or name pattern)."""
+def is_indexable_file(p: Path) -> bool:
+    """Check if a file should be indexed (by extension or name pattern).
+
+    Public API for use by watch_index and other modules.
+    """
     # Check by extension first
     if p.suffix.lower() in CODE_EXTS:
         return True
@@ -668,6 +707,10 @@ def _is_indexable_file(p: Path) -> bool:
     if fname_lower.startswith("dockerfile"):
         return True
     return False
+
+
+# Backward-compatible alias
+_is_indexable_file = is_indexable_file
 
 
 def iter_files(root: Path) -> Iterable[Path]:

--- a/scripts/mcp_indexer_server.py
+++ b/scripts/mcp_indexer_server.py
@@ -257,7 +257,7 @@ QDRANT_URL = os.environ.get("QDRANT_URL", "http://qdrant:6333")
 DEFAULT_COLLECTION = (
     os.environ.get("DEFAULT_COLLECTION")
     or os.environ.get("COLLECTION_NAME")
-    or "my-collection"
+    or "codebase"
 )
 try:
     from scripts.workspace_state import get_collection_name as _ws_get_collection_name  # type: ignore
@@ -2565,7 +2565,7 @@ async def repo_search(
         coll_hint = env_coll
 
     # Final fallback
-    env_fallback = (os.environ.get("DEFAULT_COLLECTION") or os.environ.get("COLLECTION_NAME") or "my-collection").strip()
+    env_fallback = (os.environ.get("DEFAULT_COLLECTION") or os.environ.get("COLLECTION_NAME") or "codebase").strip()
     collection = coll_hint or env_fallback
 
     _require_collection_access((sess or {}).get("user_id") if sess else None, collection, "read")

--- a/scripts/mcp_memory_server.py
+++ b/scripts/mcp_memory_server.py
@@ -36,7 +36,7 @@ QDRANT_URL = os.environ.get("QDRANT_URL", "http://qdrant:6333")
 DEFAULT_COLLECTION = (
     os.environ.get("DEFAULT_COLLECTION")
     or os.environ.get("COLLECTION_NAME")
-    or "my-collection"
+    or "codebase"
 )
 LEX_VECTOR_NAME = os.environ.get("LEX_VECTOR_NAME", "lex")
 LEX_VECTOR_DIM = int(os.environ.get("LEX_VECTOR_DIM", "4096") or 4096)

--- a/scripts/upload_service.py
+++ b/scripts/upload_service.py
@@ -105,7 +105,7 @@ logger = logging.getLogger(__name__)
 
 # Configuration from environment
 QDRANT_URL = os.environ.get("QDRANT_URL", "http://qdrant:6333")
-DEFAULT_COLLECTION = os.environ.get("COLLECTION_NAME", "my-collection")
+DEFAULT_COLLECTION = os.environ.get("COLLECTION_NAME", "codebase")
 WORK_DIR = os.environ.get("WORK_DIR") or os.environ.get("WORKDIR") or "/work"
 MAX_BUNDLE_SIZE_MB = int(os.environ.get("MAX_BUNDLE_SIZE_MB", "100"))
 UPLOAD_TIMEOUT_SECS = int(os.environ.get("UPLOAD_TIMEOUT_SECS", "300"))

--- a/scripts/watch_index.py
+++ b/scripts/watch_index.py
@@ -58,7 +58,7 @@ ROOT = Path(os.environ.get("WATCH_ROOT", "/work")).resolve()
 
 # Back-compat: legacy modules/tests expect a module-level COLLECTION constant.
 # It will be updated in main() once the resolved collection is known.
-COLLECTION = os.environ.get("COLLECTION_NAME", "my-collection")
+COLLECTION = os.environ.get("COLLECTION_NAME", "codebase")
 
 # Debounce interval
 DELAY_SECS = float(os.environ.get("WATCH_DEBOUNCE_SECS", "1.0"))
@@ -88,7 +88,7 @@ def _get_collection_for_repo(repo_path: Path) -> str:
     by consulting workspace_state. Falls back to the legacy per-repo hashed
     collection naming when no mapping exists.
     """
-    default_coll = os.environ.get("COLLECTION_NAME", "my-collection")
+    default_coll = os.environ.get("COLLECTION_NAME", "codebase")
     try:
         repo_name = _extract_repo_name_from_path(str(repo_path))
     except Exception:
@@ -154,11 +154,11 @@ def _get_collection_for_repo(repo_path: Path) -> str:
 
 def _get_collection_for_file(file_path: Path) -> str:
     if not is_multi_repo_mode():
-        return os.environ.get("COLLECTION_NAME", "my-collection")
+        return os.environ.get("COLLECTION_NAME", "codebase")
     repo_path = _detect_repo_for_file(file_path)
     if repo_path is not None:
         return _get_collection_for_repo(repo_path)
-    return os.environ.get("COLLECTION_NAME", "my-collection")
+    return os.environ.get("COLLECTION_NAME", "codebase")
 
 
 class ChangeQueue:
@@ -817,7 +817,7 @@ def main():
     except Exception:
         multi_repo_enabled = False
 
-    default_collection = os.environ.get("COLLECTION_NAME", "my-collection")
+    default_collection = os.environ.get("COLLECTION_NAME", "codebase")
     # In multi-repo mode, per-repo collections are resolved via _get_collection_for_file
     # and workspace_state; avoid deriving a root-level collection like "/work-<hash>".
     if _get_coll and not multi_repo_enabled:


### PR DESCRIPTION
The _collection function now checks the workspace state for a collection name, in addition to CLI argument and environment variable. This ensures consistency with mcp_indexer_server and improves flexibility in determining the collection name.