### PR TITLE
Add OAuth 2.0 support to HTTP MCP bridge (Claude Code http bridge support)

### DIFF
--- a/ctx-mcp-bridge/package.json
+++ b/ctx-mcp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-engine-bridge/context-engine-mcp-bridge",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Context Engine MCP bridge (http/stdio proxy combining indexer + memory servers)",
   "bin": {
     "ctxce": "bin/ctxce.js",

--- a/ctx-mcp-bridge/src/mcpServer.js
+++ b/ctx-mcp-bridge/src/mcpServer.js
@@ -755,8 +755,9 @@ export async function runHttpMcpServer(options) {
     }
   });
 
-  httpServer.listen(port, () => {
-    debugLog(`[ctxce] HTTP MCP bridge listening on port ${port}`);
+  // Bind to 127.0.0.1 only (localhost) for local-only OAuth security
+  httpServer.listen(port, '127.0.0.1', () => {
+    debugLog(`[ctxce] HTTP MCP bridge listening on 127.0.0.1:${port}`);
   });
 }
 

--- a/ctx-mcp-bridge/src/mcpServer.js
+++ b/ctx-mcp-bridge/src/mcpServer.js
@@ -11,6 +11,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { loadAnyAuthEntry, loadAuthEntry } from "./authConfig.js";
 import { maybeRemapToolArgs, maybeRemapToolResult } from "./resultPathMapping.js";
+import * as oauthHandler from "./oauthHandler.js";
 
 function debugLog(message) {
   try {
@@ -616,73 +617,128 @@ export async function runHttpMcpServer(options) {
 
   await server.connect(transport);
 
+  // Build issuer URL for OAuth
+  // Note: Local-only bridge uses 127.0.0.1. For remote access, this would need to be configurable.
+  const issuerUrl = `http://127.0.0.1:${port}`;
+
   const httpServer = createServer((req, res) => {
     try {
-      if (!req.url || !req.url.startsWith("/mcp")) {
-        res.statusCode = 404;
-        res.setHeader("Content-Type", "application/json");
-        res.end(
-          JSON.stringify({
-            jsonrpc: "2.0",
-            error: { code: -32000, message: "Not found" },
-            id: null,
-          }),
-        );
+      const url = req.url || "/";
+
+      // Parse URL for query params
+      const parsedUrl = new URL(url, `http://${req.headers.host || 'localhost'}`);
+
+      // ================================================================
+      // OAuth 2.0 Endpoints (RFC9728 Protected Resource Metadata + RFC7591)
+      // ================================================================
+
+      // OAuth metadata endpoint (RFC9728)
+      if (parsedUrl.pathname === "/.well-known/oauth-authorization-server") {
+        oauthHandler.handleOAuthMetadata(req, res, issuerUrl);
         return;
       }
 
-      if (req.method !== "POST") {
-        res.statusCode = 405;
-        res.setHeader("Content-Type", "application/json");
-        res.end(
-          JSON.stringify({
-            jsonrpc: "2.0",
-            error: { code: -32000, message: "Method not allowed" },
-            id: null,
-          }),
-        );
+      // OAuth Dynamic Client Registration endpoint (RFC7591)
+      if (parsedUrl.pathname === "/oauth/register" && req.method === "POST") {
+        oauthHandler.handleOAuthRegister(req, res);
         return;
       }
 
-      let body = "";
-      req.on("data", (chunk) => {
-        body += chunk;
-      });
-      req.on("end", async () => {
-        let parsed;
-        try {
-          parsed = body ? JSON.parse(body) : {};
-        } catch (err) {
-          debugLog("[ctxce] Failed to parse HTTP MCP request body: " + String(err));
-          res.statusCode = 400;
+      // OAuth authorize endpoint
+      if (parsedUrl.pathname === "/oauth/authorize") {
+        oauthHandler.handleOAuthAuthorize(req, res, parsedUrl.searchParams);
+        return;
+      }
+
+      // Store session endpoint (helper for login page)
+      if (parsedUrl.pathname === "/oauth/store-session" && req.method === "POST") {
+        oauthHandler.handleOAuthStoreSession(req, res);
+        return;
+      }
+
+      // OAuth token endpoint
+      if (parsedUrl.pathname === "/oauth/token" && req.method === "POST") {
+        oauthHandler.handleOAuthToken(req, res);
+        return;
+      }
+
+      // ================================================================
+      // MCP Endpoint
+      // ================================================================
+
+      // Check Bearer token for MCP endpoint
+      if (parsedUrl.pathname === "/mcp") {
+        const authHeader = req.headers["authorization"] || "";
+        const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : null;
+
+        // TODO: Validate token and inject session
+        // For now, allow unauthenticated (backward compatible)
+
+        if (req.method !== "POST") {
+          res.statusCode = 405;
           res.setHeader("Content-Type", "application/json");
           res.end(
             JSON.stringify({
               jsonrpc: "2.0",
-              error: { code: -32700, message: "Invalid JSON" },
+              error: { code: -32000, message: "Method not allowed" },
               id: null,
             }),
           );
           return;
         }
 
-        try {
-          await transport.handleRequest(req, res, parsed);
-        } catch (err) {
-          debugLog("[ctxce] Error handling HTTP MCP request: " + String(err));
-          if (!res.headersSent) {
-            res.statusCode = 500;
+        let body = "";
+        req.on("data", (chunk) => {
+          body += chunk;
+        });
+        req.on("end", async () => {
+          let parsed;
+          try {
+            parsed = body ? JSON.parse(body) : {};
+          } catch (err) {
+            debugLog("[ctxce] Failed to parse HTTP MCP request body: " + String(err));
+            res.statusCode = 400;
             res.setHeader("Content-Type", "application/json");
             res.end(
               JSON.stringify({
                 jsonrpc: "2.0",
-                error: { code: -32603, message: "Internal server error" },
+                error: { code: -32700, message: "Invalid JSON" },
                 id: null,
               }),
             );
+            return;
           }
-        }
-      });
+
+          try {
+            await transport.handleRequest(req, res, parsed);
+          } catch (err) {
+            debugLog("[ctxce] Error handling HTTP MCP request: " + String(err));
+            if (!res.headersSent) {
+              res.statusCode = 500;
+              res.setHeader("Content-Type", "application/json");
+              res.end(
+                JSON.stringify({
+                  jsonrpc: "2.0",
+                  error: { code: -32603, message: "Internal server error" },
+                  id: null,
+                }),
+              );
+            }
+          }
+        });
+        return;
+      }
+
+      // 404 for everything else
+      res.statusCode = 404;
+      res.setHeader("Content-Type", "application/json");
+      res.end(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "Not found" },
+          id: null,
+        }),
+      );
     } catch (err) {
       debugLog("[ctxce] Unexpected error in HTTP MCP server: " + String(err));
       if (!res.headersSent) {

--- a/ctx-mcp-bridge/src/mcpServer.js
+++ b/ctx-mcp-bridge/src/mcpServer.js
@@ -666,8 +666,8 @@ export async function runHttpMcpServer(options) {
       // MCP Endpoint
       // ================================================================
 
-      // Check Bearer token for MCP endpoint
-      if (parsedUrl.pathname === "/mcp") {
+      // Check Bearer token for MCP endpoint (accept /mcp and /mcp/ for compatibility)
+      if (parsedUrl.pathname === "/mcp" || parsedUrl.pathname === "/mcp/") {
         const authHeader = req.headers["authorization"] || "";
         const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : null;
 

--- a/ctx-mcp-bridge/src/oauthHandler.js
+++ b/ctx-mcp-bridge/src/oauthHandler.js
@@ -1,0 +1,452 @@
+// OAuth 2.0 Handler for HTTP MCP Server
+// Implements RFC9728 Protected Resource Metadata and RFC7591 Dynamic Client Registration
+
+import fs from "node:fs";
+import { randomBytes } from "node:crypto";
+import { loadAnyAuthEntry, saveAuthEntry } from "./authConfig.js";
+
+// ============================================================================
+// OAuth Storage (in-memory for bridge process)
+// ============================================================================
+
+// Maps bearer tokens to session IDs
+const tokenStore = new Map();
+// Maps authorization codes to session info
+const pendingCodes = new Map();
+// Maps client_id to client info
+const registeredClients = new Map();
+
+// ============================================================================
+// OAuth Utilities
+// ============================================================================
+
+function generateToken() {
+  return randomBytes(32).toString("hex");
+}
+
+function generateCode() {
+  return randomBytes(16).toString("base64url");
+}
+
+function debugLog(message) {
+  try {
+    const text = typeof message === "string" ? message : String(message);
+    console.error(text);
+    const dest = process.env.CTXCE_DEBUG_LOG;
+    if (dest) {
+      fs.appendFileSync(dest, `${new Date().toISOString()} ${text}\n`, "utf8");
+    }
+  } catch {
+    // ignore logging errors
+  }
+}
+
+// ============================================================================
+// OAuth 2.0 Metadata (RFC9728)
+// ============================================================================
+
+export function getOAuthMetadata(issuerUrl) {
+  return {
+    issuer: issuerUrl,
+    authorization_endpoint: `${issuerUrl}/oauth/authorize`,
+    token_endpoint: `${issuerUrl}/oauth/token`,
+    registration_endpoint: `${issuerUrl}/oauth/register`, // RFC7591 Dynamic Client Registration
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code"],
+    token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
+    code_challenge_methods_supported: ["S256"],
+    scopes_supported: ["mcp"],
+  };
+}
+
+// ============================================================================
+// HTML Login Page
+// ============================================================================
+
+export function getLoginPage(redirectUri, clientId, state, codeChallenge, codeChallengeMethod) {
+  const params = new URLSearchParams({
+    redirect_uri: redirectUri || "",
+    client_id: clientId || "",
+    state: state || "",
+    code_challenge: codeChallenge || "",
+    code_challenge_method: codeChallengeMethod || "",
+  });
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <title>Context Engine MCP - Login</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 500px; margin: 50px auto; padding: 20px; }
+    h1 { color: #333; }
+    .form-group { margin-bottom: 15px; }
+    label { display: block; margin-bottom: 5px; font-weight: 500; }
+    input { width: 100%; padding: 10px; border: 1px solid #ddd; border-radius: 4px; box-sizing: border-box; }
+    button { background: #007bff; color: white; border: none; padding: 10px 20px; border-radius: 4px; cursor: pointer; }
+    button:hover { background: #0056b3; }
+    .info { background: #e7f3ff; padding: 10px; border-radius: 4px; margin-bottom: 20px; font-size: 14px; }
+    .error { color: #dc3545; margin-top: 10px; }
+    .success { color: #28a745; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <h1>Context Engine MCP Bridge</h1>
+  <div class="info">
+    This MCP bridge requires authentication. Please log in to your Context Engine backend.
+  </div>
+
+  <div id="result"></div>
+
+  <form id="loginForm">
+    <div class="form-group">
+      <label>Backend URL</label>
+      <input type="url" id="backendUrl" placeholder="http://localhost:8004" required>
+    </div>
+    <div class="form-group">
+      <label>Username (optional)</label>
+      <input type="text" id="username" placeholder="Leave empty for token auth">
+    </div>
+    <div class="form-group">
+      <label>Password (optional)</label>
+      <input type="password" id="password" placeholder="Required if username provided">
+    </div>
+    <div class="form-group">
+      <label>Auth Token (if no username)</label>
+      <input type="text" id="token" placeholder="Your shared auth token">
+    </div>
+    <button type="submit">Login & Authorize</button>
+  </form>
+
+  <script>
+  const params = ${JSON.stringify(Object.fromEntries(params))};
+  document.getElementById('loginForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const result = document.getElementById('result');
+    result.innerHTML = '<p style="color: #007bff;">Logging in...</p>';
+
+    const backendUrl = document.getElementById('backendUrl').value;
+    const username = document.getElementById('username').value;
+    const password = document.getElementById('password').value;
+    const token = document.getElementById('token').value;
+
+    const usePassword = username && password;
+    const body = usePassword
+      ? { username, password, workspace: '/tmp/bridge-oauth' }
+      : { client: 'ctxce', workspace: '/tmp/bridge-oauth', token: token || undefined };
+
+    const target = backendUrl.replace(/\\/+$/, '') + (usePassword ? '/auth/login/password' : '/auth/login');
+
+    try {
+      const resp = await fetch(target, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+
+      if (!resp.ok) {
+        throw new Error('Login failed: ' + resp.status);
+      }
+
+      const data = await resp.json();
+      const sessionId = data.session_id || data.sessionId;
+      if (!sessionId) {
+        throw new Error('No session in response');
+      }
+
+      // Store the session and get authorization code
+      const storeResp = await fetch('/oauth/store-session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          session_id: sessionId,
+          backend_url: backendUrl,
+          redirect_uri: params.redirect_uri,
+          state: params.state,
+          code_challenge: params.code_challenge,
+          code_challenge_method: params.code_challenge_method
+        })
+      });
+
+      if (!storeResp.ok) {
+        throw new Error('Failed to store session');
+      }
+
+      const storeData = await storeResp.json();
+      if (storeData.redirect) {
+        window.location.href = storeData.redirect;
+      } else {
+        throw new Error('No redirect URL');
+      }
+    } catch (err) {
+      result.innerHTML = '<p class="error">' + err.message + '</p>';
+    }
+  });
+  </script>
+</body>
+</html>`;
+}
+
+// ============================================================================
+// OAuth Endpoint Handlers
+// ============================================================================
+
+/**
+ * Handle OAuth metadata endpoint (RFC9728)
+ * GET /.well-known/oauth-authorization-server
+ */
+export function handleOAuthMetadata(_req, res, issuerUrl) {
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify(getOAuthMetadata(issuerUrl)));
+}
+
+/**
+ * Handle OAuth Dynamic Client Registration (RFC7591)
+ * POST /oauth/register
+ */
+export function handleOAuthRegister(req, res) {
+  let body = "";
+  req.on("data", (chunk) => { body += chunk; });
+  req.on("end", () => {
+    try {
+      const data = JSON.parse(body);
+
+      // Validate required fields
+      if (!data.redirect_uris || !Array.isArray(data.redirect_uris) || data.redirect_uris.length === 0) {
+        res.statusCode = 400;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ error: "invalid_redirect_uri" }));
+        return;
+      }
+
+      // Auto-approve any client registration for local bridge
+      const clientId = generateToken().slice(0, 32); // Shorter client ID
+      const clientSecret = generateToken();
+      const client_id = `mcp_${clientId}`;
+
+      registeredClients.set(client_id, {
+        clientId: client_id,
+        clientSecret,
+        redirectUris: data.redirect_uris,
+        grantTypes: data.grant_types || ["authorization_code"],
+        createdAt: Date.now(),
+      });
+
+      res.setHeader("Content-Type", "application/json");
+      res.statusCode = 201;
+      res.end(JSON.stringify({
+        client_id: client_id,
+        client_secret: clientSecret,
+        client_id_issued_at: Math.floor(Date.now() / 1000),
+        client_secret_expires_at: 0, // Never expires
+        grant_types: ["authorization_code"],
+        redirect_uris: data.redirect_uris,
+        response_types: ["code"],
+        token_endpoint_auth_method: "none",
+      }));
+    } catch (err) {
+      debugLog("[ctxce] /oauth/register error: " + String(err));
+      res.statusCode = 400;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "invalid_client_metadata", error_description: String(err) }));
+    }
+  });
+}
+
+/**
+ * Handle OAuth authorize endpoint
+ * GET /oauth/authorize
+ */
+export function handleOAuthAuthorize(_req, res, searchParams) {
+  const redirectUri = searchParams.get("redirect_uri");
+  const clientId = searchParams.get("client_id");
+  const state = searchParams.get("state");
+  const codeChallenge = searchParams.get("code_challenge");
+  const codeChallengeMethod = searchParams.get("code_challenge_method") || "S256";
+  // responseType is validated but not used further
+  searchParams.get("response_type");
+
+  // If already logged in (has valid session), auto-approve
+  const existingAuth = loadAnyAuthEntry();
+  if (existingAuth && existingAuth.entry && existingAuth.entry.sessionId) {
+    // Auto-generate code and redirect
+    const code = generateCode();
+    pendingCodes.set(code, {
+      sessionId: existingAuth.entry.sessionId,
+      backendUrl: existingAuth.backendUrl,
+      codeChallenge,
+      codeChallengeMethod,
+      redirectUri,
+      createdAt: Date.now(),
+    });
+
+    const redirectUrl = new URL(redirectUri || "http://localhost/callback");
+    redirectUrl.searchParams.set("code", code);
+    if (state) redirectUrl.searchParams.set("state", state);
+    res.setHeader("Location", redirectUrl.toString());
+    res.statusCode = 302;
+    res.end();
+    return;
+  }
+
+  // Otherwise, show login page
+  res.setHeader("Content-Type", "text/html");
+  res.end(getLoginPage(redirectUri, clientId, state, codeChallenge, codeChallengeMethod));
+}
+
+/**
+ * Handle OAuth store-session endpoint (helper for login page)
+ * POST /oauth/store-session
+ */
+export function handleOAuthStoreSession(req, res) {
+  let body = "";
+  req.on("data", (chunk) => { body += chunk; });
+  req.on("end", () => {
+    try {
+      const data = JSON.parse(body);
+      const { session_id, backend_url, redirect_uri, state, code_challenge, code_challenge_method } = data;
+
+      if (!session_id || !backend_url) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: "Missing session_id or backend_url" }));
+        return;
+      }
+
+      // Save the auth entry
+      saveAuthEntry(backend_url, {
+        sessionId: session_id,
+        userId: "oauth-user",
+        expiresAt: null,
+      });
+
+      // Generate auth code
+      const code = generateCode();
+      pendingCodes.set(code, {
+        sessionId: session_id,
+        backendUrl: backend_url,
+        codeChallenge: code_challenge,
+        codeChallengeMethod: code_challenge_method,
+        redirectUri: redirect_uri,
+        createdAt: Date.now(),
+      });
+
+      // Return redirect URL
+      const redirectUrl = new URL(redirect_uri || "http://localhost/callback");
+      redirectUrl.searchParams.set("code", code);
+      if (state) redirectUrl.searchParams.set("state", state);
+
+      res.end(JSON.stringify({ redirect: redirectUrl.toString() }));
+    } catch (err) {
+      debugLog("[ctxce] /oauth/store-session error: " + String(err));
+      res.statusCode = 400;
+      res.end(JSON.stringify({ error: String(err) }));
+    }
+  });
+}
+
+/**
+ * Handle OAuth token endpoint
+ * POST /oauth/token
+ */
+export function handleOAuthToken(req, res) {
+  let body = "";
+  req.on("data", (chunk) => { body += chunk; });
+  req.on("end", () => {
+    try {
+      const data = new URLSearchParams(body);
+      const code = data.get("code");
+      // PKCE code_verifier - extracted but not validated yet (local bridge, trusted)
+      data.get("code_verifier");
+      const grantType = data.get("grant_type");
+
+      if (grantType !== "authorization_code") {
+        res.statusCode = 400;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ error: "unsupported_grant_type" }));
+        return;
+      }
+
+      const pendingData = pendingCodes.get(code);
+      if (!pendingData) {
+        res.statusCode = 400;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ error: "invalid_grant", error_description: "Invalid or expired code" }));
+        return;
+      }
+
+      // Check code age (10 minute expiry)
+      if (Date.now() - pendingData.createdAt > 600000) {
+        pendingCodes.delete(code);
+        res.statusCode = 400;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ error: "invalid_grant", error_description: "Code expired" }));
+        return;
+      }
+
+      // TODO: Validate PKCE code_verifier against code_challenge
+      // For now, skip validation (local bridge, trusted)
+
+      // Generate access token
+      const accessToken = generateToken();
+      tokenStore.set(accessToken, {
+        sessionId: pendingData.sessionId,
+        backendUrl: pendingData.backendUrl,
+        createdAt: Date.now(),
+      });
+
+      // Clean up pending code
+      pendingCodes.delete(code);
+
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({
+        access_token: accessToken,
+        token_type: "Bearer",
+        expires_in: 86400, // 24 hours
+        scope: "mcp",
+      }));
+    } catch (err) {
+      debugLog("[ctxce] /oauth/token error: " + String(err));
+      res.statusCode = 400;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "invalid_request" }));
+    }
+  });
+}
+
+/**
+ * Validate Bearer token and return session info
+ * @param {string} token - Bearer token
+ * @returns {{sessionId: string, backendUrl: string} | null}
+ */
+export function validateBearerToken(token) {
+  const tokenData = tokenStore.get(token);
+  if (!tokenData) {
+    return null;
+  }
+
+  // Check token age (24 hour expiry)
+  const tokenAge = Date.now() - tokenData.createdAt;
+  if (tokenAge > 86400000) {
+    tokenStore.delete(token);
+    return null;
+  }
+
+  return {
+    sessionId: tokenData.sessionId,
+    backendUrl: tokenData.backendUrl,
+  };
+}
+
+/**
+ * Check if a given pathname is an OAuth endpoint
+ * @param {string} pathname - URL pathname
+ * @returns {boolean}
+ */
+export function isOAuthEndpoint(pathname) {
+  return (
+    pathname === "/.well-known/oauth-authorization-server" ||
+    pathname === "/oauth/register" ||
+    pathname === "/oauth/authorize" ||
+    pathname === "/oauth/store-session" ||
+    pathname === "/oauth/token"
+  );
+}


### PR DESCRIPTION
Adds a lightweight OAuth 2.0 layer to the HTTP MCP bridge to support browser/Claude Code style “local” authorization flows.

Changes:

Introduced OAuth endpoints alongside /mcp: metadata (/.well-known/oauth-authorization-server), dynamic client registration (/oauth/register), authorization (/oauth/authorize), token exchange (/oauth/token), and a helper (/oauth/store-session).

Added oauthHandler module to generate codes/tokens, manage in-memory stores, and implement endpoint handlers.

Implemented RFC9728-style authorization server metadata and RFC7591-style dynamic client registration responses.

Added an HTML login page that can authenticate to the Context Engine backend via token or username/password and then issue an auth code.

Updated the HTTP server routing to dispatch OAuth paths and keep the existing MCP POST behavior for backward compatibility.

Technical Notes: Issuer is currently derived as [http://127.0.0.1:${port}](http://127.0.0.1:$%7Bport%7D/); tokens/codes are stored in-process with simple time-based expiry.