### PR TITLE
Integrate OpenLit observability and memory_find tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -339,6 +339,40 @@ INFO_REQUEST_CONTEXT_LINES=5
 
 
 # ---------------------------------------------------------------------------
+# OpenLit Observability (OFF by default)
+# ---------------------------------------------------------------------------
+# Self-hosted LLM/vector-DB tracing via OpenTelemetry.
+#
+# Dashboard: http://localhost:3000
+#   Email: user@openlit.io
+#   Password: openlituser
+#
+# To enable: set OPENLIT_ENABLED=1 and ensure openlit SDK is installed.
+# Traces LLM calls (GLM, Ollama, llama.cpp) and Qdrant operations automatically.
+
+# Master toggle for OpenLit instrumentation
+OPENLIT_ENABLED=0
+
+# OTLP endpoint for trace export (OpenLit's built-in collector)
+# Port 4317 = gRPC, Port 4318 = HTTP (default)
+OTEL_EXPORTER_OTLP_ENDPOINT=http://openlit:4318
+
+# Application name shown in traces
+OPENLIT_APP_NAME=context-engine
+
+# Environment tag for filtering traces (development, staging, production)
+OPENLIT_ENVIRONMENT=development
+
+# ClickHouse backend (used by OpenLit for storing traces)
+# OPENLIT_CLICKHOUSE_HOST=clickhouse
+# OPENLIT_CLICKHOUSE_PORT=8123
+# OPENLIT_CLICKHOUSE_USER=default
+# OPENLIT_CLICKHOUSE_PASSWORD=OPENLIT
+# OPENLIT_CLICKHOUSE_DATABASE=openlit
+
+
+
+# ---------------------------------------------------------------------------
 # Optional Auth & Bridge Configuration (OFF by default)
 # ---------------------------------------------------------------------------
 

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -8,7 +8,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     TRANSFORMERS_CACHE=/tmp/cache
 
 # Install deps + create cache/rerank directories in single layer
-RUN pip install --no-cache-dir --upgrade mcp fastmcp qdrant-client fastembed \
+# Pin qdrant-client to 1.15.x - version 1.16+ removed .search() which breaks OpenLit instrumentation
+RUN pip install --no-cache-dir --upgrade mcp fastmcp 'qdrant-client>=1.15.0,<1.16.0' fastembed openlit \
     && mkdir -p /tmp/cache && chmod 755 /tmp/cache \
     && mkdir -p /tmp/rerank_events /tmp/rerank_weights \
     && chmod 777 /tmp/rerank_events /tmp/rerank_weights

--- a/config/clickhouse-config.xml
+++ b/config/clickhouse-config.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<clickhouse>
+    <logger>
+        <level>warning</level>
+        <console>true</console>
+    </logger>
+    
+    <trace_log>
+        <level>6</level>
+        <flush_interval_milliseconds>120000</flush_interval_milliseconds>
+        <table_ttl>604800</table_ttl>
+    </trace_log>
+    
+    <text_log>
+        <level>warning</level>
+        <table_ttl>604800</table_ttl>
+        <flush_interval_milliseconds>120000</flush_interval_milliseconds>
+    </text_log>
+    
+    <query_log>
+        <log_queries_min_query_duration_ms>1000</log_queries_min_query_duration_ms>
+        <flush_interval_milliseconds>60000</flush_interval_milliseconds>
+        <table_ttl>604800</table_ttl>
+    </query_log>
+    
+    <metric_log>
+        <collect_interval_milliseconds>60000</collect_interval_milliseconds>
+        <flush_interval_milliseconds>120000</flush_interval_milliseconds>
+        <table_ttl>604800</table_ttl>
+    </metric_log>
+    
+    <asynchronous_metric_log>
+        <collect_interval_milliseconds>60000</collect_interval_milliseconds>
+        <flush_interval_milliseconds>120000</flush_interval_milliseconds>
+        <table_ttl>604800</table_ttl>
+    </asynchronous_metric_log>
+    
+    <part_log>
+        <level>warning</level>
+        <flush_interval_milliseconds>120000</flush_interval_milliseconds>
+        <table_ttl>604800</table_ttl>
+    </part_log>
+</clickhouse>
+

--- a/config/otel-collector-config.yaml
+++ b/config/otel-collector-config.yaml
@@ -1,0 +1,49 @@
+# OpenTelemetry Collector configuration for OpenLit
+# Receives telemetry from openlit SDK and exports to ClickHouse
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+  memory_limiter:
+    limit_mib: 1500
+    spike_limit_mib: 512
+    check_interval: 5s
+
+exporters:
+  clickhouse:
+    endpoint: tcp://${env:INIT_DB_HOST}:9000?dial_timeout=10s
+    database: ${env:INIT_DB_DATABASE}
+    username: ${env:INIT_DB_USERNAME}
+    password: ${env:INIT_DB_PASSWORD}
+    ttl: 730h
+    logs_table_name: otel_logs
+    traces_table_name: otel_traces
+    metrics_table_name: otel_metrics
+    timeout: 5s
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [clickhouse]
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [clickhouse]
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [clickhouse]

--- a/docker-compose.openlit.yml
+++ b/docker-compose.openlit.yml
@@ -1,0 +1,78 @@
+# OpenLit Observability Stack - POC
+# Usage: docker compose -f docker-compose.yml -f docker-compose.openlit.yml up -d
+#
+# This adds OpenLit observability to your existing Context-Engine stack.
+# Dashboard: http://localhost:3000 (login: user@openlit.io / openlituser)
+
+services:
+  # ClickHouse - storage backend for OpenLit
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.4.1
+    container_name: openlit-clickhouse
+    ports:
+      - "9000:9000"   # Native protocol (for OTEL exporter)
+      - "8123:8123"   # HTTP interface (for dashboard queries)
+    volumes:
+      - clickhouse_data:/var/lib/clickhouse
+      - ./config/clickhouse-config.xml:/etc/clickhouse-server/config.d/custom-config.xml:ro
+    environment:
+      - CLICKHOUSE_PASSWORD=OPENLIT
+      - CLICKHOUSE_USER=default
+    healthcheck:
+      test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - dev-remote-network
+
+  # OpenLit Dashboard (has built-in OTEL collector)
+  openlit:
+    image: ghcr.io/openlit/openlit:latest
+    container_name: openlit-dashboard
+    ports:
+      - "3000:3000"   # Dashboard UI
+      - "4317:4317"   # OTLP gRPC receiver
+      - "4318:4318"   # OTLP HTTP receiver
+    environment:
+      - INIT_DB_HOST=clickhouse
+      - INIT_DB_PORT=8123
+      - INIT_DB_DATABASE=openlit
+      - INIT_DB_USERNAME=default
+      - INIT_DB_PASSWORD=OPENLIT
+      - SQLITE_DATABASE_URL=file:/app/client/data/data.db
+    volumes:
+      - openlit_data:/app/client/data
+      - ./config/otel-collector-config.yaml:/etc/otel/otel-collector-config.yaml:ro
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+    networks:
+      - dev-remote-network
+
+  # Enable OpenLit observability for MCP services
+  mcp:
+    environment:
+      - OPENLIT_ENABLED=1
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://openlit:4318
+
+  mcp_http:
+    environment:
+      - OPENLIT_ENABLED=1
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://openlit:4318
+
+  mcp_indexer:
+    environment:
+      - OPENLIT_ENABLED=1
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://openlit:4318
+
+  mcp_indexer_http:
+    environment:
+      - OPENLIT_ENABLED=1
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://openlit:4318
+
+volumes:
+  clickhouse_data:
+    driver: local
+  openlit_data:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,9 @@ services:
       - FASTMCP_HOST=${FASTMCP_HOST}
       - FASTMCP_PORT=${FASTMCP_PORT}
       - QDRANT_URL=${QDRANT_URL}
+      # OpenLit observability (optional - enable via OPENLIT_ENABLED=1)
+      - OPENLIT_ENABLED=${OPENLIT_ENABLED:-0}
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://openlit:4318}
       # Optional auth configuration (fully opt-in via .env)
       - CTXCE_AUTH_ENABLED=${CTXCE_AUTH_ENABLED:-0}
       - CTXCE_MCP_ACL_ENFORCE=${CTXCE_MCP_ACL_ENFORCE:-0}
@@ -96,6 +99,9 @@ services:
       - FASTMCP_HOST=${FASTMCP_HOST}
       - FASTMCP_INDEXER_PORT=${FASTMCP_INDEXER_PORT}
       - QDRANT_URL=${QDRANT_URL}
+      # OpenLit observability (optional)
+      - OPENLIT_ENABLED=${OPENLIT_ENABLED:-0}
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4318}
       # Optional auth configuration (fully opt-in via .env)
       - CTXCE_AUTH_ENABLED=${CTXCE_AUTH_ENABLED:-0}
       - CTXCE_MCP_ACL_ENFORCE=${CTXCE_MCP_ACL_ENFORCE:-0}
@@ -214,6 +220,9 @@ services:
       - FASTMCP_PORT=8000
       - FASTMCP_TRANSPORT=${FASTMCP_HTTP_TRANSPORT}
       - QDRANT_URL=${QDRANT_URL}
+      # OpenLit observability (optional - enable via OPENLIT_ENABLED=1)
+      - OPENLIT_ENABLED=${OPENLIT_ENABLED:-0}
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://openlit:4318}
       # Optional auth configuration (fully opt-in via .env)
       - CTXCE_AUTH_ENABLED=${CTXCE_AUTH_ENABLED:-0}
       - CTXCE_MCP_ACL_ENFORCE=${CTXCE_MCP_ACL_ENFORCE:-0}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Context Engine Architecture
 
-**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
+**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Observability](OBSERVABILITY.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2,7 +2,7 @@
 
 Complete environment variable reference for Context Engine.
 
-**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
+**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Observability](OBSERVABILITY.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
 
 ---
 

--- a/docs/CTX_CLI.md
+++ b/docs/CTX_CLI.md
@@ -2,7 +2,7 @@
 
 CLI that retrieves code context and rewrites input into context-aware prompts using the local LLM decoder. Works with questions and commands/instructions.
 
-**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
+**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Observability](OBSERVABILITY.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 Setting up development environment, understanding codebase structure, and contributing to Context Engine.
 
-**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
+**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Observability](OBSERVABILITY.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,6 +1,6 @@
 # Getting Started (VS Code Extension)
 
-**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
+**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Observability](OBSERVABILITY.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
 
 This guide covers the detailed setup flow using the VS Code extension for the lowest-friction Context-Engine experience.
 

--- a/docs/IDE_CLIENTS.md
+++ b/docs/IDE_CLIENTS.md
@@ -2,7 +2,7 @@
 
 Connect IDE to running Context-Engine stack. No need to clone this repo into your project.
 
-**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
+**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Observability](OBSERVABILITY.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
 
 ---
 

--- a/docs/MCP_API.md
+++ b/docs/MCP_API.md
@@ -2,7 +2,7 @@
 
 This document provides comprehensive API documentation for all MCP (Model Context Protocol) tools exposed by Context Engine's dual-server architecture.
 
-**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
+**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Observability](OBSERVABILITY.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
 
 ---
 

--- a/docs/MEMORY_GUIDE.md
+++ b/docs/MEMORY_GUIDE.md
@@ -2,7 +2,7 @@
 
 Best practices for using Context Engine's memory system effectively.
 
-**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
+**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Observability](OBSERVABILITY.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
 
 ---
 

--- a/docs/MULTI_REPO_COLLECTIONS.md
+++ b/docs/MULTI_REPO_COLLECTIONS.md
@@ -1,6 +1,6 @@
 # Multi-Repository Collection Architecture
 
-**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
+**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Observability](OBSERVABILITY.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
 
 ---
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,91 @@
+# Observability with OpenLit
+
+Self-hosted LLM and vector database tracing via OpenTelemetry.
+
+**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Observability](OBSERVABILITY.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
+
+---
+
+Context-Engine integrates with [OpenLit](https://github.com/openlit/openlit) for self-hosted LLM and vector database observability via OpenTelemetry.
+
+## Quick Start
+
+### 1. Start the Stack
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.openlit.yml up -d
+```
+
+### 2. Access Dashboard
+
+- **URL**: http://localhost:3000
+- **Email**: `user@openlit.io`
+- **Password**: `openlituser`
+
+### 3. Enable Tracing
+
+Set in your `.env`:
+
+```bash
+OPENLIT_ENABLED=1
+```
+
+## Architecture
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  MCP Indexer    │────▶│    OpenLit      │────▶│   ClickHouse    │
+│  MCP Memory     │     │  (OTLP 4318)    │     │   (Port 8123)   │
+│  Context-Engine │     │  Dashboard:3000 │     │                 │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+```
+
+## What Gets Traced
+
+| Component | Operations |
+|-----------|------------|
+| **Qdrant** | `.search()`, `.scroll()`, `.upsert()`, `.delete()` |
+| **LLMs** | GLM-4.x, Ollama, llama.cpp (via OpenAI-compatible API) |
+| **Search** | `repo_search`, `context_search`, `context_answer` |
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPENLIT_ENABLED` | `0` | Master toggle |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://openlit:4318` | OTLP HTTP endpoint |
+| `OPENLIT_APP_NAME` | `context-engine` | Application name in traces |
+| `OPENLIT_ENVIRONMENT` | `development` | Environment tag |
+
+## Ports
+
+| Port | Service | Purpose |
+|------|---------|---------|
+| 3000 | OpenLit | Dashboard UI |
+| 4317 | OpenLit | OTLP gRPC receiver |
+| 4318 | OpenLit | OTLP HTTP receiver |
+| 8123 | ClickHouse | HTTP interface |
+| 9000 | ClickHouse | Native protocol |
+
+## Troubleshooting
+
+### No Qdrant traces appearing
+
+The `openlit` SDK must be initialized **before** importing `QdrantClient`. Context-Engine handles this via `scripts/openlit_init.py`, which is imported at the top of MCP server entrypoints.
+
+**Required import order:**
+```python
+# 1. OpenLit init FIRST
+from scripts import openlit_init
+
+# 2. Then everything else
+from qdrant_client import QdrantClient
+```
+
+### Qdrant client version
+
+Use `qdrant-client>=1.15.0,<1.16.0`. Version 1.16+ changed to `.query_points()` which breaks OpenLit's instrumentation hooks.
+
+## Disabling
+
+Set `OPENLIT_ENABLED=0` or remove from environment. The SDK gracefully no-ops when disabled.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -2,7 +2,7 @@
 
 Common issues and solutions for Context Engine.
 
-**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
+**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Observability](OBSERVABILITY.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
 
 ---
 

--- a/docs/vscode-extension.md
+++ b/docs/vscode-extension.md
@@ -2,7 +2,7 @@
 
 Context Engine Uploader extension for automatic workspace sync and Prompt+ integration.
 
-**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
+**Documentation:** [README](../README.md) · [Getting Started](GETTING_STARTED.md) · [Configuration](CONFIGURATION.md) · [IDE Clients](IDE_CLIENTS.md) · [MCP API](MCP_API.md) · [ctx CLI](CTX_CLI.md) · [Memory Guide](MEMORY_GUIDE.md) · [Architecture](ARCHITECTURE.md) · [Multi-Repo](MULTI_REPO_COLLECTIONS.md) · [Observability](OBSERVABILITY.md) · [Kubernetes](../deploy/kubernetes/README.md) · [VS Code Extension](vscode-extension.md) · [Troubleshooting](TROUBLESHOOTING.md) · [Development](DEVELOPMENT.md)
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Runtime dependencies (mirrors Dockerfiles)
-qdrant-client
+# Pin to 1.15.x - version 1.16+ removed .search() method which breaks OpenLit instrumentation
+qdrant-client>=1.15.0,<1.16.0
 fastembed
 watchdog
 onnxruntime
@@ -30,6 +31,7 @@ uvicorn[standard]
 python-multipart
 jinja2
 openai>=1.0
+openlit>=1.0.0  # LLM observability SDK
 
 # Test-only
 pytest

--- a/scripts/mcp_indexer_server.py
+++ b/scripts/mcp_indexer_server.py
@@ -171,7 +171,6 @@ from scripts.mcp_impl.info_request import (
     _calculate_confidence,
 )
 from scripts.mcp_impl.admin_tools import _collection_map_impl
-from scripts.mcp_impl.memory import _memory_store_impl, _memory_find_impl
 from scripts.mcp_impl.search_specialized import (
     _search_tests_for_impl,
     _search_config_for_impl,
@@ -732,30 +731,6 @@ async def collection_map(
         include_samples=include_samples,
         limit=limit,
         coerce_bool_fn=_coerce_bool,
-    )
-
-
-# ---------------------------------------------------------------------------
-# memory_store - thin wrapper delegating to _memory_store_impl
-# ---------------------------------------------------------------------------
-@mcp.tool()
-async def memory_store(
-    information: str,
-    metadata: Optional[Dict[str, Any]] = None,
-    collection: Optional[str] = None,
-) -> Dict[str, Any]:
-    """Store a free-form memory entry in Qdrant using the active collection.
-
-    - Embeds the text and writes both dense and lexical vectors (plus mini vector in ReFRAG mode).
-    - Honors explicit collection overrides; otherwise falls back to workspace/env defaults.
-    - Returns a payload compatible with context-aware tools.
-    """
-    return await _memory_store_impl(
-        information=information,
-        metadata=metadata,
-        collection=collection,
-        default_collection_fn=_default_collection,
-        get_embedding_model_fn=_get_embedding_model,
     )
 
 
@@ -1980,41 +1955,6 @@ async def expand_query(
     - {"alternates": list[str]} or {"alternates": [], "hint": "..."} if decoder disabled
     """
     return await _expand_query_impl(query=query, max_new=max_new, session=session)
-
-
-# ---------------------------------------------------------------------------
-# memory_find - thin wrapper delegating to _memory_find_impl
-# ---------------------------------------------------------------------------
-@mcp.tool()
-async def memory_find(
-    query: str,
-    limit: Optional[int] = None,
-    collection: Optional[str] = None,
-    top_k: Optional[int] = None,
-) -> Dict[str, Any]:
-    """Find memory entries by vector similarity (dense + lexical fusion).
-
-    When to use:
-    - Search for previously stored memories/notes
-    - Retrieve context from the memory collection
-
-    Parameters:
-    - query: str. Search query text.
-    - limit: int (default 5). Maximum results to return.
-    - collection: str (optional). Target collection override.
-    - top_k: int (optional). Alias for limit.
-
-    Returns:
-    - {ok: true, results: [{id, score, information, metadata}, ...], count: N}
-    """
-    return await _memory_find_impl(
-        query=query,
-        limit=limit,
-        collection=collection,
-        top_k=top_k,
-        default_collection_fn=_default_collection,
-        get_embedding_model_fn=_get_embedding_model,
-    )
 
 
 _relax_var_kwarg_defaults()

--- a/scripts/mcp_memory_server.py
+++ b/scripts/mcp_memory_server.py
@@ -1,19 +1,27 @@
+# ---------------------------------------------------------------------------
+# CRITICAL: OpenLit must be initialized BEFORE any qdrant_client imports
+# to properly instrument vector DB calls.
+# ---------------------------------------------------------------------------
 import os
+import sys as _sys
+
+# Ensure repo roots are importable so 'scripts' resolves inside container
+_roots_env = os.environ.get("WORK_ROOTS", "")
+_roots = [p.strip() for p in _roots_env.split(",") if p.strip()] or ["/work", "/app"]
+for _root in _roots:
+    if _root and _root not in _sys.path:
+        _sys.path.insert(0, _root)
+
+# Now import OpenLit init (before any other scripts imports that may use qdrant)
+try:
+    from scripts import openlit_init  # noqa: F401 - triggers early instrumentation
+except ImportError:
+    pass  # OpenLit not available
+
 from typing import Any, Dict, Optional, List
 import json
 import threading
 from weakref import WeakKeyDictionary
-
-# Ensure repo roots are importable so 'scripts' resolves inside container
-import sys as _sys
-_roots_env = os.environ.get("WORK_ROOTS", "")
-_roots = [p.strip() for p in _roots_env.split(",") if p.strip()] or ["/work", "/app"]
-try:
-    for _root in _roots:
-        if _root and _root not in _sys.path:
-            _sys.path.insert(0, _root)
-except Exception:
-    pass
 
 
 # FastMCP server and request Context (ctx) for per-connection state
@@ -425,6 +433,10 @@ def find(
     Cold-start option: set MEMORY_COLD_SKIP_DENSE=1 to skip dense embedding until the
     model is cached (useful on slow storage).
     """
+    # Handle 'q' alias for query (from kwargs)
+    if not query and kwargs.get("q"):
+        query = kwargs.get("q")
+
     sess = _require_auth_session(session)
     coll = _resolve_collection(collection, session=session, ctx=ctx, extra_kwargs=kwargs)
     _require_collection_access((sess or {}).get("user_id") if sess else None, coll, "read")

--- a/scripts/mcp_memory_server.py
+++ b/scripts/mcp_memory_server.py
@@ -550,7 +550,6 @@ def memory_store(
     collection: Optional[str] = None,
     session: Optional[str] = None,
     ctx: Context = None,
-    **kwargs: Any,
 ) -> Dict[str, Any]:
     """Store a memory entry into Qdrant (alias for 'store').
 
@@ -562,7 +561,6 @@ def memory_store(
         collection=collection,
         session=session,
         ctx=ctx,
-        **kwargs,
     )
 
 
@@ -574,7 +572,6 @@ def memory_find(
     top_k: Optional[int] = None,
     session: Optional[str] = None,
     ctx: Context = None,
-    **kwargs: Any,
 ) -> Dict[str, Any]:
     """Find memory entries by vector similarity (alias for 'find').
 
@@ -588,7 +585,6 @@ def memory_find(
         top_k=top_k,
         session=session,
         ctx=ctx,
-        **kwargs,
     )
 
 

--- a/scripts/mcp_memory_server.py
+++ b/scripts/mcp_memory_server.py
@@ -536,6 +536,62 @@ def find(
     return {"ok": True, "results": ordered, "count": len(ordered)}
 
 
+# =============================================================================
+# Aliases: memory_store and memory_find
+# These aliases ensure proper routing through the MCP bridge (which routes
+# tool names containing "memory" to the memory server). They wrap the original
+# store/find functions for backward compatibility.
+# =============================================================================
+
+@mcp.tool()
+def memory_store(
+    information: str,
+    metadata: Optional[Dict[str, Any]] = None,
+    collection: Optional[str] = None,
+    session: Optional[str] = None,
+    ctx: Context = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Store a memory entry into Qdrant (alias for 'store').
+
+    First call may be slower because the embedding model loads lazily.
+    """
+    return store(
+        information=information,
+        metadata=metadata,
+        collection=collection,
+        session=session,
+        ctx=ctx,
+        **kwargs,
+    )
+
+
+@mcp.tool()
+def memory_find(
+    query: str,
+    limit: Optional[int] = None,
+    collection: Optional[str] = None,
+    top_k: Optional[int] = None,
+    session: Optional[str] = None,
+    ctx: Context = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Find memory entries by vector similarity (alias for 'find').
+
+    Cold-start option: set MEMORY_COLD_SKIP_DENSE=1 to skip dense embedding until the
+    model is cached (useful on slow storage).
+    """
+    return find(
+        query=query,
+        limit=limit,
+        collection=collection,
+        top_k=top_k,
+        session=session,
+        ctx=ctx,
+        **kwargs,
+    )
+
+
 def _resolve_collection(
     collection: Optional[str],
     session: Optional[str] = None,

--- a/scripts/openlit_init.py
+++ b/scripts/openlit_init.py
@@ -1,0 +1,75 @@
+"""
+openlit_init.py - Early OpenLit initialization for instrumentation.
+
+This module MUST be imported before any qdrant_client, openai, or other
+instrumented libraries to ensure OpenLit can properly wrap their classes.
+
+Usage:
+    import scripts.openlit_init  # Import early in entrypoint
+    
+Or in __init__.py:
+    from scripts import openlit_init  # Ensure early load
+"""
+import os
+
+_OPENLIT_INITIALIZED = False
+_OPENLIT_ENABLED = os.environ.get("OPENLIT_ENABLED", "0").lower() in ("1", "true", "yes")
+
+
+def init_openlit():
+    """Initialize OpenLit instrumentation. Safe to call multiple times."""
+    global _OPENLIT_INITIALIZED
+    
+    if _OPENLIT_INITIALIZED or not _OPENLIT_ENABLED:
+        return _OPENLIT_INITIALIZED
+    
+    try:
+        import openlit
+        
+        _otel_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://openlit:4318")
+        _app_name = os.environ.get("OPENLIT_APP_NAME", "context-engine")
+        _environment = os.environ.get("OPENLIT_ENVIRONMENT", "development")
+        
+        # Initialize OpenLit - this patches imported libraries
+        openlit.init(
+            otlp_endpoint=_otel_endpoint,
+            application_name=_app_name,
+            environment=_environment,
+            disabled_instrumentors=None,  # Don't disable anything
+        )
+        
+        print(f"[OpenLit] Initialized with endpoint={_otel_endpoint}, app={_app_name}")
+        
+        # Explicitly instrument Qdrant (belt-and-suspenders for late imports)
+        try:
+            from openlit.instrumentation.qdrant import QdrantInstrumentor
+            
+            # Get tracer provider if available
+            tracer_provider = None
+            if hasattr(openlit, 'tracer_provider'):
+                tracer_provider = openlit.tracer_provider
+            
+            QdrantInstrumentor().instrument(
+                tracer_provider=tracer_provider,
+                environment=_environment,
+                application_name=_app_name,
+            )
+            print("[OpenLit] Qdrant instrumentation enabled")
+        except ImportError:
+            print("[OpenLit] Qdrant instrumentor not found (openlit may be outdated)")
+        except Exception as e:
+            print(f"[OpenLit] Qdrant instrumentation failed: {e}")
+        
+        _OPENLIT_INITIALIZED = True
+        
+    except ImportError:
+        print("[OpenLit] SDK not installed, skipping observability")
+    except Exception as e:
+        print(f"[OpenLit] Failed to initialize: {e}")
+    
+    return _OPENLIT_INITIALIZED
+
+
+# Auto-initialize on import if OPENLIT_ENABLED=1
+if _OPENLIT_ENABLED:
+    init_openlit()


### PR DESCRIPTION
Adds OpenLit observability support across services and scripts, including Docker and Compose configuration, early initialization for proper instrumentation, and environment variable controls. Introduces a new memory_find tool for hybrid vector search in memory.py and exposes it via mcp_indexer_server.py. Pins qdrant-client to 1.15.x for OpenLit compatibility and updates requirements accordingly.