### PR TITLE
Add tree-sitter symbol extractors and symbol graph tool

### DIFF
--- a/scripts/ingest/chunking.py
+++ b/scripts/ingest/chunking.py
@@ -48,7 +48,9 @@ def chunk_semantic(
     # Try enhanced AST analyzer first (if available)
     # Note: ast_analyzer can use Python's built-in ast module even without tree-sitter
     use_enhanced = os.environ.get("INDEX_USE_ENHANCED_AST", "1").lower() in {"1", "true", "yes", "on"}
-    _ast_supported = language in _TS_LANGUAGES or language == "python"  # Python has built-in ast fallback
+    # Enhanced AST analyzer is intended for languages it can reliably structure-chunk.
+    # Keep this tight so other languages fall through to symbol-range chunking.
+    _ast_supported = language in {"python", "javascript", "typescript"}
     if use_enhanced and _AST_ANALYZER_AVAILABLE and _ast_supported:
         try:
             chunks = chunk_code_semantically(text, language, max_lines, overlap)

--- a/scripts/ingest/chunking.py
+++ b/scripts/ingest/chunking.py
@@ -66,14 +66,11 @@ def chunk_semantic(
             if os.environ.get("DEBUG_INDEXING"):
                 print(f"[DEBUG] Enhanced AST chunking failed, falling back: {e}")
     
-    if not _use_tree_sitter() or language not in _TS_LANGUAGES:
-        # Fallback to line-based chunking
-        return chunk_lines(text, max_lines, overlap)
-
     lines = text.splitlines()
     n = len(lines)
 
-    # Extract symbols with line ranges
+    # Extract symbols with line ranges (works for many languages via regex fallbacks,
+    # and may optionally use tree-sitter when enabled).
     symbols = _extract_symbols(language, text)
     if not symbols:
         return chunk_lines(text, max_lines, overlap)

--- a/scripts/mcp_impl/symbol_graph.py
+++ b/scripts/mcp_impl/symbol_graph.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""
+mcp_impl/symbol_graph.py - Symbol graph navigation for code understanding.
+
+Provides Qdrant-native queries for:
+- "who calls X" (callers)
+- "where is X defined" (definition)
+- "what imports Y" (importers)
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "_symbol_graph_impl",
+    "_format_symbol_graph_toon",
+]
+
+# Environment - use same patterns as rest of engine
+QDRANT_URL = os.environ.get("QDRANT_URL", "http://qdrant:6333")
+
+def _norm_under(u: Optional[str]) -> Optional[str]:
+    """Normalize an `under` path to match ingest's stored `metadata.path_prefix` values.
+
+    This mirrors the engine's convention: normalize to a /work/... style path.
+    Note: `under` in this engine is an exact directory filter (not recursive).
+    """
+    if not u:
+        return None
+    s = str(u).strip().replace("\\", "/")
+    s = "/".join([p for p in s.split("/") if p])
+    if not s:
+        return None
+    # Normalize to /work/...
+    if not s.startswith("/"):
+        v = "/work/" + s
+    else:
+        v = "/work/" + s.lstrip("/") if not s.startswith("/work/") else s
+    return v.rstrip("/")
+
+
+async def _symbol_graph_impl(
+    symbol: str,
+    query_type: str = "callers",
+    limit: int = 20,
+    language: Optional[str] = None,
+    under: Optional[str] = None,
+    collection: Optional[str] = None,
+    session: Optional[str] = None,
+    ctx: Any = None,
+) -> Dict[str, Any]:
+    """
+    Query the symbol graph to find callers, definitions, or importers.
+
+    Args:
+        symbol: The symbol name to search for (function, class, module name)
+        query_type: One of "callers", "definition", "importers"
+        limit: Maximum number of results
+        language: Optional language filter
+        under: Optional path prefix filter
+        collection: Optional collection override
+        session: Optional session ID for collection routing
+        ctx: MCP context (optional)
+
+    Returns:
+        Dict with "results" list and metadata
+    """
+    from qdrant_client import QdrantClient
+    from qdrant_client import models as qmodels
+
+    # Get collection using engine's standard approach
+    coll = str(collection or "").strip()
+    if not coll:
+        try:
+            from scripts.mcp_impl.workspace import _default_collection
+            coll = _default_collection() or ""
+        except Exception:
+            coll = os.environ.get("COLLECTION_NAME", "codebase")
+    if not coll:
+        coll = os.environ.get("COLLECTION_NAME", "codebase")
+
+    # Connect to Qdrant using engine's standard env vars
+    try:
+        client = QdrantClient(
+            url=QDRANT_URL,
+            api_key=os.environ.get("QDRANT_API_KEY"),
+            timeout=float(os.environ.get("QDRANT_TIMEOUT", "20") or 20),
+        )
+    except Exception as e:
+        logger.error(f"Failed to connect to Qdrant: {e}")
+        return {
+            "results": [],
+            "error": f"Qdrant connection failed: {e}",
+            "symbol": symbol,
+            "query_type": query_type,
+            "collection": coll,
+        }
+
+    # Validate query_type
+    if query_type not in ("callers", "definition", "importers"):
+        return {
+            "results": [],
+            "error": f"Invalid query_type: {query_type}. Use 'callers', 'definition', or 'importers'",
+            "symbol": symbol,
+            "query_type": query_type,
+            "collection": coll,
+        }
+
+    results = []
+
+    try:
+        if query_type == "callers":
+            # Find chunks where metadata.calls array contains the symbol (exact match)
+            results = await _query_array_field(
+                client=client,
+                collection=coll,
+                field_key="metadata.calls",
+                value=symbol,
+                limit=limit,
+                language=language,
+                under=_norm_under(under),
+            )
+        elif query_type == "definition":
+            # Find chunks where symbol_path matches the symbol
+            results = await _query_definition(
+                client=client,
+                collection=coll,
+                symbol=symbol,
+                limit=limit,
+                language=language,
+                under=_norm_under(under),
+            )
+        elif query_type == "importers":
+            # Find chunks where metadata.imports array contains the symbol
+            results = await _query_array_field(
+                client=client,
+                collection=coll,
+                field_key="metadata.imports",
+                value=symbol,
+                limit=limit,
+                language=language,
+                under=_norm_under(under),
+            )
+
+        # If no results, fall back to semantic search
+        if not results:
+            results = await _fallback_semantic_search(
+                symbol=symbol,
+                query_type=query_type,
+                limit=limit,
+                language=language,
+                collection=coll,
+                session=session,
+            )
+
+    except Exception as e:
+        logger.warning(f"symbol_graph query failed: {e}")
+        # Fall back to semantic search
+        results = await _fallback_semantic_search(
+            symbol=symbol,
+            query_type=query_type,
+            limit=limit,
+            language=language,
+            collection=coll,
+            session=session,
+        )
+
+    return {
+        "results": results,
+        "symbol": symbol,
+        "query_type": query_type,
+        "count": len(results),
+        "collection": coll,
+    }
+
+
+async def _query_array_field(
+    client: Any,
+    collection: str,
+    field_key: str,
+    value: str,
+    limit: int,
+    language: Optional[str] = None,
+    under: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Query for points where an array field contains a specific value.
+    Uses MatchAny for exact array element matching.
+    """
+    from qdrant_client import models as qmodels
+
+    must_conditions = [
+        # Use MatchAny for exact element match in arrays
+        qmodels.FieldCondition(
+            key=field_key,
+            match=qmodels.MatchAny(any=[value]),
+        )
+    ]
+
+    # Add optional filters
+    if language:
+        must_conditions.append(
+            qmodels.FieldCondition(
+                key="metadata.language",
+                match=qmodels.MatchValue(value=language.lower()),
+            )
+        )
+
+    if under:
+        must_conditions.append(
+            qmodels.FieldCondition(
+                key="metadata.path_prefix",
+                match=qmodels.MatchValue(value=under),
+            )
+        )
+
+    query_filter = qmodels.Filter(must=must_conditions)
+
+    def scroll_query():
+        return client.scroll(
+            collection_name=collection,
+            scroll_filter=query_filter,
+            limit=limit,
+            with_payload=True,
+            with_vectors=False,
+        )
+
+    scroll_result = await asyncio.to_thread(scroll_query)
+    points = scroll_result[0] if scroll_result else []
+
+    return [_format_point(pt) for pt in points[:limit]]
+
+
+async def _query_definition(
+    client: Any,
+    collection: str,
+    symbol: str,
+    limit: int,
+    language: Optional[str] = None,
+    under: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Query for symbol definitions using symbol_path or symbol fields.
+    """
+    from qdrant_client import models as qmodels
+
+    results = []
+
+    # Build base conditions for optional filters
+    base_conditions = []
+    if language:
+        base_conditions.append(
+            qmodels.FieldCondition(
+                key="metadata.language",
+                match=qmodels.MatchValue(value=language.lower()),
+            )
+        )
+    if under:
+        base_conditions.append(
+            qmodels.FieldCondition(
+                key="metadata.path_prefix",
+                match=qmodels.MatchValue(value=under),
+            )
+        )
+
+    # Strategy 1: Exact match on symbol_path (e.g., "MyClass.my_method")
+    try:
+        filter1 = qmodels.Filter(
+            must=[
+                qmodels.FieldCondition(
+                    key="metadata.symbol_path",
+                    match=qmodels.MatchValue(value=symbol),
+                )
+            ] + base_conditions
+        )
+
+        def scroll1():
+            return client.scroll(
+                collection_name=collection,
+                scroll_filter=filter1,
+                limit=limit,
+                with_payload=True,
+                with_vectors=False,
+            )
+
+        scroll_result = await asyncio.to_thread(scroll1)
+        points = scroll_result[0] if scroll_result else []
+        results.extend(points)
+    except Exception as e:
+        logger.debug(f"symbol_path exact match failed: {e}")
+
+    # Strategy 2: Exact match on symbol field
+    if len(results) < limit:
+        try:
+            filter2 = qmodels.Filter(
+                must=[
+                    qmodels.FieldCondition(
+                        key="metadata.symbol",
+                        match=qmodels.MatchValue(value=symbol),
+                    )
+                ] + base_conditions
+            )
+
+            def scroll2():
+                return client.scroll(
+                    collection_name=collection,
+                    scroll_filter=filter2,
+                    limit=limit - len(results),
+                    with_payload=True,
+                    with_vectors=False,
+                )
+
+            scroll_result = await asyncio.to_thread(scroll2)
+            points = scroll_result[0] if scroll_result else []
+            results.extend(points)
+        except Exception as e:
+            logger.debug(f"symbol exact match failed: {e}")
+
+    # Strategy 3: Text search on symbol_path for partial matches (e.g., "my_method" in "MyClass.my_method")
+    if len(results) < limit:
+        try:
+            filter3 = qmodels.Filter(
+                must=[
+                    qmodels.FieldCondition(
+                        key="metadata.symbol_path",
+                        match=qmodels.MatchText(text=symbol),
+                    )
+                ] + base_conditions
+            )
+
+            def scroll3():
+                return client.scroll(
+                    collection_name=collection,
+                    scroll_filter=filter3,
+                    limit=limit - len(results),
+                    with_payload=True,
+                    with_vectors=False,
+                )
+
+            scroll_result = await asyncio.to_thread(scroll3)
+            points = scroll_result[0] if scroll_result else []
+            results.extend(points)
+        except Exception as e:
+            logger.debug(f"symbol_path text match failed: {e}")
+
+    # Deduplicate by point ID
+    seen_ids = set()
+    unique_results = []
+    for pt in results:
+        pt_id = getattr(pt, "id", None)
+        if pt_id not in seen_ids:
+            seen_ids.add(pt_id)
+            unique_results.append(pt)
+
+    return [_format_point(pt) for pt in unique_results[:limit]]
+
+
+def _get_path(pt: Any) -> str:
+    """Extract path from point payload."""
+    payload = getattr(pt, "payload", {}) or {}
+    md = payload.get("metadata", payload)
+    return str(md.get("path") or md.get("file_path") or "")
+
+
+def _format_point(pt: Any) -> Dict[str, Any]:
+    """Format a Qdrant point for the API response."""
+    payload = getattr(pt, "payload", {}) or {}
+    md = payload.get("metadata", payload)
+
+    # Get code snippet from correct field: "information" is the indexed text
+    snippet = ""
+    info = payload.get("information") or payload.get("document") or ""
+    if info:
+        # The information field contains: "HEADER\n<CODE>\ncode here\n</CODE>"
+        # Extract code from between markers if present
+        if "<CODE>" in info and "</CODE>" in info:
+            try:
+                start = info.index("<CODE>") + 6
+                end = info.index("</CODE>")
+                snippet = info[start:end].strip()[:500]
+            except Exception:
+                snippet = info[:500]
+        else:
+            snippet = info[:500]
+
+    result = {
+        "path": str(md.get("path") or md.get("file_path") or ""),
+        "start_line": int(md.get("start_line") or md.get("start") or 0),
+        "end_line": int(md.get("end_line") or md.get("end") or 0),
+        "symbol": str(md.get("symbol") or ""),
+        "symbol_path": str(md.get("symbol_path") or ""),
+        "language": str(md.get("language") or ""),
+        "snippet": snippet,
+        "calls": md.get("calls") or [],
+        "imports": md.get("imports") or [],
+    }
+
+    return result
+
+
+async def _fallback_semantic_search(
+    symbol: str,
+    query_type: str,
+    limit: int = 20,
+    language: Optional[str] = None,
+    collection: Optional[str] = None,
+    session: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Fallback to semantic search when filter-based search returns no results.
+    """
+    # Construct a query based on what we're looking for
+    query_prefixes = {
+        "callers": f"code that calls {symbol}",
+        "definition": f"definition of {symbol} function class",
+        "importers": f"code that imports {symbol}",
+    }
+    query = query_prefixes.get(query_type, symbol)
+
+    try:
+        from scripts.mcp_impl.search import _repo_search_impl
+
+        search_result = await _repo_search_impl(
+            query=query,
+            limit=limit,
+            language=language,
+            session=session,
+        )
+
+        return search_result.get("results", [])
+
+    except Exception as e:
+        logger.warning(f"Fallback semantic search failed: {e}")
+        return []
+
+
+def _format_symbol_graph_toon(result: Dict[str, Any]) -> str:
+    """Format symbol graph results in TOON format for token efficiency."""
+    lines = []
+    query_type = result.get("query_type", "")
+    symbol = result.get("symbol", "")
+    results = result.get("results", [])
+
+    if not results:
+        return f"≡ SYMBOL_GRAPH | {query_type} | {symbol}\n⚠ No results found"
+
+    lines.append(f"≡ SYMBOL_GRAPH | {query_type} | {symbol} | {len(results)} results")
+
+    for r in results:
+        path = r.get("path", "")
+        start = r.get("start_line", 0)
+        end = r.get("end_line", 0)
+        sym = r.get("symbol_path") or r.get("symbol") or ""
+
+        line = f"→ {path}:{start}-{end}"
+        if sym:
+            line += f" | {sym}"
+
+        lines.append(line)
+
+    return "\n".join(lines)

--- a/tests/test_ingest_chunking.py
+++ b/tests/test_ingest_chunking.py
@@ -22,7 +22,8 @@ def test_chunk_semantic_fallback_no_ts(monkeypatch):
     monkeypatch.setenv("USE_TREE_SITTER", "0")
     text = "\n".join(f"L{i}" for i in range(1, 26))
     chunks = ing.chunk_semantic(text, language="python", max_lines=8, overlap=3)
-    # Should behave like chunk_lines but with is_semantic key added
+    # Should behave like chunk_lines because there are no symbols in this text,
+    # regardless of tree-sitter availability.
     chunks2 = ing.chunk_lines(text, max_lines=8, overlap=3)
     # Compare ignoring the is_semantic key (added by chunk_semantic wrapper)
     for c in chunks:

--- a/tests/test_semantic_chunking_multilang.py
+++ b/tests/test_semantic_chunking_multilang.py
@@ -1,0 +1,69 @@
+import importlib
+
+
+ing = importlib.import_module("scripts.ingest_code")
+
+
+def test_chunk_semantic_go_without_tree_sitter(monkeypatch):
+    # Even with tree-sitter disabled, Go symbol extraction is regex-based and should
+    # enable semantic chunking around functions/types.
+    monkeypatch.setenv("USE_TREE_SITTER", "0")
+    go = "\n".join(
+        [
+            "package main",
+            "",
+            "type Foo struct {",
+            "  X int",
+            "}",
+            "",
+            "func (f *Foo) Bar(a int) int {",
+            "  return a + 1",
+            "}",
+            "",
+            "func Baz() {",
+            "  Bar(1)",
+            "}",
+        ]
+    )
+    chunks = ing.chunk_semantic(go, language="go", max_lines=50, overlap=3)
+    assert any(c.get("symbol") in {"Foo", "Bar", "Baz"} for c in chunks)
+
+
+def test_chunk_semantic_java_without_tree_sitter(monkeypatch):
+    monkeypatch.setenv("USE_TREE_SITTER", "0")
+    java = "\n".join(
+        [
+            "package demo;",
+            "import java.util.*;",
+            "public class A {",
+            "  public void foo() {",
+            "    bar();",
+            "  }",
+            "  public void bar() {",
+            "  }",
+            "}",
+        ]
+    )
+    chunks = ing.chunk_semantic(java, language="java", max_lines=50, overlap=3)
+    assert any(c.get("symbol") in {"A", "foo", "bar"} for c in chunks)
+
+
+def test_chunk_semantic_csharp_without_tree_sitter(monkeypatch):
+    monkeypatch.setenv("USE_TREE_SITTER", "0")
+    cs = "\n".join(
+        [
+            "using System;",
+            "namespace Demo {",
+            "  public class A {",
+            "    public void Foo() {",
+            "      Bar();",
+            "    }",
+            "    public void Bar() {}",
+            "  }",
+            "}",
+        ]
+    )
+    chunks = ing.chunk_semantic(cs, language="csharp", max_lines=50, overlap=3)
+    assert any(c.get("symbol") in {"A", "Foo", "Bar"} for c in chunks)
+
+

--- a/tests/test_symbol_graph_tool.py
+++ b/tests/test_symbol_graph_tool.py
@@ -1,0 +1,39 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_symbol_graph_under_uses_path_prefix_matchvalue():
+    # Import internal helper to validate filter construction without needing a real Qdrant instance.
+    from qdrant_client import models as qmodels
+    from scripts.mcp_impl import symbol_graph as sg
+
+    captured = {}
+
+    class FakeClient:
+        def scroll(self, *, collection_name, scroll_filter, limit, with_payload, with_vectors):
+            captured["collection_name"] = collection_name
+            captured["scroll_filter"] = scroll_filter
+            return ([], None)
+
+    await sg._query_array_field(  # type: ignore[attr-defined]
+        client=FakeClient(),
+        collection="codebase",
+        field_key="metadata.calls",
+        value="foo",
+        limit=10,
+        language="python",
+        under=sg._norm_under("scripts"),  # type: ignore[attr-defined]
+    )
+
+    flt = captured.get("scroll_filter")
+    assert isinstance(flt, qmodels.Filter)
+    must = list(flt.must or [])
+    keys = [getattr(c, "key", None) for c in must]
+    assert "metadata.path_prefix" in keys
+
+    # Ensure it's an exact match (MatchValue), not substring (MatchText)
+    cond = next(c for c in must if getattr(c, "key", None) == "metadata.path_prefix")
+    assert isinstance(cond.match, qmodels.MatchValue)
+    assert cond.match.value == "/work/scripts"
+
+

--- a/tests/test_ts_extractors.py
+++ b/tests/test_ts_extractors.py
@@ -1,0 +1,320 @@
+"""
+tests/test_ts_extractors.py - Tests for tree-sitter symbol extraction.
+
+Tests the new tree-sitter extraction handlers for Go, Java, Rust, C#, and Bash.
+"""
+import pytest
+import os
+
+# Temporarily disable tree-sitter to test extractors directly
+os.environ["USE_TREE_SITTER"] = "1"
+
+from scripts.ingest.symbols import (
+    _ts_extract_symbols_go,
+    _ts_extract_symbols_java,
+    _ts_extract_symbols_rust,
+    _ts_extract_symbols_csharp,
+    _ts_extract_symbols_bash,
+    _ts_extract_symbols,
+)
+
+
+class TestGoExtractor:
+    """Test Go tree-sitter extraction."""
+
+    def test_go_function(self):
+        """Test Go function extraction."""
+        code = '''package main
+
+func HelloWorld() {
+    fmt.Println("Hello")
+}
+
+func main() {
+    HelloWorld()
+}
+'''
+        syms = _ts_extract_symbols_go(code)
+        if not syms:  # Tree-sitter not available
+            pytest.skip("tree-sitter-go not installed")
+        names = [s.get("name") for s in syms]
+        assert "HelloWorld" in names
+        assert "main" in names
+
+    def test_go_method(self):
+        """Test Go method extraction."""
+        code = '''package main
+
+type Server struct {
+    host string
+}
+
+func (s *Server) Start() error {
+    return nil
+}
+
+func (s Server) Stop() {
+}
+'''
+        syms = _ts_extract_symbols_go(code)
+        if not syms:
+            pytest.skip("tree-sitter-go not installed")
+        
+        # Find methods
+        methods = [s for s in syms if s.get("kind") == "method"]
+        method_names = [m.get("name") for m in methods]
+        assert "Start" in method_names
+        assert "Stop" in method_names
+        
+        # Check path includes receiver
+        start_method = next((m for m in methods if m.get("name") == "Start"), None)
+        if start_method:
+            assert "Server" in str(start_method.get("path", ""))
+
+    def test_go_struct_interface(self):
+        """Test Go struct/interface extraction."""
+        code = '''package main
+
+type Handler interface {
+    Handle(req Request) Response
+}
+
+type MyHandler struct {
+    name string
+}
+'''
+        syms = _ts_extract_symbols_go(code)
+        if not syms:
+            pytest.skip("tree-sitter-go not installed")
+        
+        kinds = {s.get("name"): s.get("kind") for s in syms}
+        assert kinds.get("Handler") == "interface"
+        assert kinds.get("MyHandler") == "struct"
+
+
+class TestJavaExtractor:
+    """Test Java tree-sitter extraction."""
+
+    def test_java_class_methods(self):
+        """Test Java class and method extraction."""
+        code = '''public class Calculator {
+    public int add(int a, int b) {
+        return a + b;
+    }
+    
+    private int subtract(int a, int b) {
+        return a - b;
+    }
+}
+'''
+        syms = _ts_extract_symbols_java(code)
+        if not syms:
+            pytest.skip("tree-sitter-java not installed")
+        
+        names = [s.get("name") for s in syms]
+        assert "Calculator" in names
+        assert "add" in names
+        assert "subtract" in names
+        
+        # Check method paths
+        add_method = next((s for s in syms if s.get("name") == "add"), None)
+        if add_method:
+            assert add_method.get("path") == "Calculator.add"
+
+    def test_java_interface(self):
+        """Test Java interface extraction."""
+        code = '''public interface Repository {
+    void save(Object entity);
+    Object findById(String id);
+}
+'''
+        syms = _ts_extract_symbols_java(code)
+        if not syms:
+            pytest.skip("tree-sitter-java not installed")
+        
+        repo = next((s for s in syms if s.get("name") == "Repository"), None)
+        assert repo is not None
+        assert repo.get("kind") == "interface"
+
+
+class TestRustExtractor:
+    """Test Rust tree-sitter extraction."""
+
+    def test_rust_functions(self):
+        """Test Rust function extraction."""
+        code = '''fn main() {
+    println!("Hello");
+}
+
+pub fn greet(name: &str) -> String {
+    format!("Hello, {}", name)
+}
+'''
+        syms = _ts_extract_symbols_rust(code)
+        if not syms:
+            pytest.skip("tree-sitter-rust not installed")
+        
+        names = [s.get("name") for s in syms]
+        assert "main" in names
+        assert "greet" in names
+
+    def test_rust_structs_impl(self):
+        """Test Rust struct and impl extraction."""
+        code = '''pub struct Config {
+    host: String,
+    port: u16,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Config { host: "localhost".to_string(), port: 8080 }
+    }
+    
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+}
+'''
+        syms = _ts_extract_symbols_rust(code)
+        if not syms:
+            pytest.skip("tree-sitter-rust not installed")
+        
+        # Should find struct and impl methods
+        names = [s.get("name") for s in syms]
+        assert "Config" in names
+        assert "new" in names
+        assert "host" in names
+        
+        # Methods should have impl path
+        new_fn = next((s for s in syms if s.get("name") == "new"), None)
+        if new_fn:
+            assert "Config" in str(new_fn.get("path", ""))
+
+    def test_rust_traits(self):
+        """Test Rust trait extraction."""
+        code = '''pub trait Handler {
+    fn handle(&self, req: Request) -> Response;
+}
+'''
+        syms = _ts_extract_symbols_rust(code)
+        if not syms:
+            pytest.skip("tree-sitter-rust not installed")
+        
+        handler = next((s for s in syms if s.get("name") == "Handler"), None)
+        assert handler is not None
+        assert handler.get("kind") == "trait"
+
+
+class TestCSharpExtractor:
+    """Test C# tree-sitter extraction."""
+
+    def test_csharp_class_methods(self):
+        """Test C# class and method extraction."""
+        code = '''public class UserService
+{
+    private readonly IRepository _repo;
+    
+    public UserService(IRepository repo)
+    {
+        _repo = repo;
+    }
+    
+    public User GetById(string id)
+    {
+        return _repo.Find(id);
+    }
+}
+'''
+        syms = _ts_extract_symbols_csharp(code)
+        if not syms:
+            pytest.skip("tree-sitter-c-sharp not installed")
+        
+        names = [s.get("name") for s in syms]
+        assert "UserService" in names
+        assert "GetById" in names
+
+    def test_csharp_interface(self):
+        """Test C# interface extraction."""
+        code = '''public interface IRepository
+{
+    void Save(object entity);
+    object Find(string id);
+}
+'''
+        syms = _ts_extract_symbols_csharp(code)
+        if not syms:
+            pytest.skip("tree-sitter-c-sharp not installed")
+        
+        repo = next((s for s in syms if s.get("name") == "IRepository"), None)
+        assert repo is not None
+        assert repo.get("kind") == "interface"
+
+
+class TestBashExtractor:
+    """Test Bash/Shell tree-sitter extraction."""
+
+    def test_bash_functions(self):
+        """Test Bash function extraction."""
+        code = '''#!/bin/bash
+
+function setup() {
+    echo "Setting up..."
+}
+
+cleanup() {
+    echo "Cleaning up..."
+}
+
+main() {
+    setup
+    do_work
+    cleanup
+}
+'''
+        syms = _ts_extract_symbols_bash(code)
+        if not syms:
+            pytest.skip("tree-sitter-bash not installed")
+        
+        names = [s.get("name") for s in syms]
+        # At minimum should find function definitions
+        assert len(syms) >= 1
+        # Check that we have function kinds
+        kinds = [s.get("kind") for s in syms]
+        assert "function" in kinds
+
+
+class TestDispatcher:
+    """Test the _ts_extract_symbols dispatcher."""
+
+    def test_dispatcher_routes_go(self):
+        """Test dispatcher routes Go correctly."""
+        code = "func main() {}"
+        syms = _ts_extract_symbols("go", code)
+        # If tree-sitter-go is available, should return symbols
+        assert isinstance(syms, list)
+
+    def test_dispatcher_routes_java(self):
+        """Test dispatcher routes Java correctly."""
+        code = "public class Foo {}"
+        syms = _ts_extract_symbols("java", code)
+        assert isinstance(syms, list)
+
+    def test_dispatcher_routes_rust(self):
+        """Test dispatcher routes Rust correctly."""
+        code = "fn main() {}"
+        syms = _ts_extract_symbols("rust", code)
+        assert isinstance(syms, list)
+
+    def test_dispatcher_routes_csharp(self):
+        """Test dispatcher routes C# correctly."""
+        code = "public class Foo {}"
+        for lang in ["csharp", "c_sharp"]:
+            syms = _ts_extract_symbols(lang, code)
+            assert isinstance(syms, list)
+
+    def test_dispatcher_routes_bash(self):
+        """Test dispatcher routes Bash correctly."""
+        code = "function foo() { echo hi; }"
+        for lang in ["bash", "shell", "sh"]:
+            syms = _ts_extract_symbols(lang, code)
+            assert isinstance(syms, list)


### PR DESCRIPTION
Introduces tree-sitter-based symbol extraction for Go, Java, Rust, C#, and Bash in scripts/ingest/symbols.py, and adds a new symbol graph tool for querying callers, definitions, and importers in scripts/mcp_impl/symbol_graph.py. Updates chunking logic to use symbol extraction for more languages, exposes the symbol_graph tool in the indexer server, and adds comprehensive tests for the new extractors and symbol graph functionality.