### PR TITLE
Revert TransportSecuritySettings - breaks bridge and non-Docker deployments

### DIFF
--- a/scripts/mcp_indexer_server.py
+++ b/scripts/mcp_indexer_server.py
@@ -287,34 +287,7 @@ from scripts.mcp_workspace import (
     _work_script,
 )
 
-# Configure transport security to allow Docker internal hostnames
-# This prevents "Invalid Host header: mcp:8000" errors from inter-container calls
-try:
-    from mcp.server.transport_security import TransportSecuritySettings
-    _transport_security = TransportSecuritySettings(
-        enable_dns_rebinding_protection=True,
-        allowed_hosts=[
-            "localhost:*",
-            "127.0.0.1:*",
-            "0.0.0.0:*",
-            "mcp:*",           # Docker service name
-            "mcp_http:*",      # Docker service name (HTTP variant)
-            "indexer:*",       # Docker service name
-            "mcp-search:*",    # Docker container name pattern
-            "mcp-search-dev-remote:*",
-            "mcp-search-http-dev-remote:*",
-        ],
-        allowed_origins=[
-            "http://localhost:*",
-            "http://127.0.0.1:*",
-            "http://mcp:*",
-            "http://mcp_http:*",
-        ],
-    )
-except ImportError:
-    _transport_security = None
-
-mcp = FastMCP(APP_NAME, transport_security=_transport_security)
+mcp = FastMCP(APP_NAME)
 
 
 # Capture tool registry automatically by wrapping the decorator once

--- a/scripts/mcp_memory_server.py
+++ b/scripts/mcp_memory_server.py
@@ -122,34 +122,7 @@ def _ensure_once(name: str) -> bool:
     except Exception:
         return False
 
-# Configure transport security to allow Docker internal hostnames
-# This prevents "Invalid Host header: mcp:8000" errors from inter-container calls
-try:
-    from mcp.server.transport_security import TransportSecuritySettings
-    _transport_security = TransportSecuritySettings(
-        enable_dns_rebinding_protection=True,
-        allowed_hosts=[
-            "localhost:*",
-            "127.0.0.1:*",
-            "0.0.0.0:*",
-            "mcp:*",           # Docker service name
-            "mcp_http:*",      # Docker service name (HTTP variant)
-            "memory:*",        # Docker service name
-            "mcp-search:*",    # Docker container name pattern
-            "mcp-search-dev-remote:*",
-            "mcp-search-http-dev-remote:*",
-        ],
-        allowed_origins=[
-            "http://localhost:*",
-            "http://127.0.0.1:*",
-            "http://mcp:*",
-            "http://mcp_http:*",
-        ],
-    )
-except ImportError:
-    _transport_security = None
-
-mcp = FastMCP(name="memory-server", transport_security=_transport_security)
+mcp = FastMCP(name="memory-server")
 
 # Capture tool registry automatically by wrapping the decorator once
 _TOOLS_REGISTRY: list[dict] = []


### PR DESCRIPTION
Reverts 4ec4208. The hardcoded allowed_hosts whitelist breaks:
- ctx-mcp-bridge (primary extension access pattern)
- K8s deployments (LAN IPs, internal DNS)
- Any custom domain deployment

If host validation is needed, it should be opt-in via env var (auth already exists).