### PR TITLE
Disable DNS rebinding protection for FastMCP in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies for all services
+# Pin mcp/fastmcp versions to match requirements.txt for consistency across services
 RUN pip install --no-cache-dir --upgrade \
     qdrant-client \
     fastembed \
@@ -22,8 +23,8 @@ RUN pip install --no-cache-dir --upgrade \
     tokenizers \
     tree_sitter \
     tree_sitter_languages \
-    mcp \
-    fastmcp
+    'mcp==1.17.0' \
+    'fastmcp==2.12.4'
 
 # Copy scripts for all services
 COPY scripts /app/scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,18 +13,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies for all services
-# Pin mcp/fastmcp versions to match requirements.txt for consistency across services
-RUN pip install --no-cache-dir --upgrade \
-    qdrant-client \
-    fastembed \
-    watchdog \
-    onnxruntime \
-    tokenizers \
-    tree_sitter \
-    tree_sitter_languages \
-    'mcp==1.17.0' \
-    'fastmcp==2.12.4'
+# Python deps: reuse shared requirements file for consistency across services
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade -r /tmp/requirements.txt
 
 # Copy scripts for all services
 COPY scripts /app/scripts

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -7,15 +7,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     HF_HOME=/tmp/cache \
     TRANSFORMERS_CACHE=/tmp/cache
 
-# Install deps + create cache/rerank directories in single layer
-# Pin versions to match requirements.txt for consistency across services
-# Pin qdrant-client to 1.15.x - version 1.16+ removed .search() which breaks OpenLit instrumentation
-RUN pip install --no-cache-dir --upgrade \
-    'mcp==1.17.0' \
-    'fastmcp==2.12.4' \
-    'qdrant-client>=1.15.0,<1.16.0' \
-    fastembed \
-    openlit \
+# Python deps: reuse shared requirements file for consistency across services
+# Create cache/rerank directories in same layer
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade -r /tmp/requirements.txt \
     && mkdir -p /tmp/cache && chmod 755 /tmp/cache \
     && mkdir -p /tmp/rerank_events /tmp/rerank_weights \
     && chmod 777 /tmp/rerank_events /tmp/rerank_weights

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -8,8 +8,14 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     TRANSFORMERS_CACHE=/tmp/cache
 
 # Install deps + create cache/rerank directories in single layer
+# Pin versions to match requirements.txt for consistency across services
 # Pin qdrant-client to 1.15.x - version 1.16+ removed .search() which breaks OpenLit instrumentation
-RUN pip install --no-cache-dir --upgrade mcp fastmcp 'qdrant-client>=1.15.0,<1.16.0' fastembed openlit \
+RUN pip install --no-cache-dir --upgrade \
+    'mcp==1.17.0' \
+    'fastmcp==2.12.4' \
+    'qdrant-client>=1.15.0,<1.16.0' \
+    fastembed \
+    openlit \
     && mkdir -p /tmp/cache && chmod 755 /tmp/cache \
     && mkdir -p /tmp/rerank_events /tmp/rerank_weights \
     && chmod 777 /tmp/rerank_events /tmp/rerank_weights

--- a/scripts/mcp_indexer_server.py
+++ b/scripts/mcp_indexer_server.py
@@ -213,10 +213,9 @@ except Exception:
 
 
 try:
-    # Official MCP Python SDK (FastMCP convenience server)
     from mcp.server.fastmcp import FastMCP, Context  # type: ignore
+    from mcp.server.transport_security import TransportSecuritySettings  # type: ignore
 except Exception as e:  # pragma: no cover
-    # Keep FastMCP import error loud; Context is for type hints only
     raise SystemExit("mcp package is required inside the container: pip install mcp")
 
 APP_NAME = os.environ.get("FASTMCP_SERVER_NAME", "qdrant-indexer-mcp")
@@ -287,7 +286,11 @@ from scripts.mcp_workspace import (
     _work_script,
 )
 
-mcp = FastMCP(APP_NAME)
+# Disable DNS rebinding protection - breaks Docker internal networking (Host: mcp:8000)
+mcp = FastMCP(
+    APP_NAME,
+    transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+)
 
 
 # Capture tool registry automatically by wrapping the decorator once


### PR DESCRIPTION
Updated both mcp_indexer_server.py and mcp_memory_server.py to disable DNS rebinding protection in FastMCP by setting transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False). This change is necessary to allow proper internal networking when running the servers inside Docker containers.