### PR TITLE
Add file hash cache clearing after Qdrant collection recreation

### DIFF
--- a/scripts/ingest/qdrant.py
+++ b/scripts/ingest/qdrant.py
@@ -25,6 +25,19 @@ from scripts.ingest.config import (
     logical_repo_reuse_enabled,
 )
 
+# Import cache clearing function (lazy to avoid circular imports)
+_clear_file_hash_cache = None
+
+def _get_clear_file_hash_cache():
+    global _clear_file_hash_cache
+    if _clear_file_hash_cache is None:
+        try:
+            from scripts.workspace_state import clear_file_hash_cache
+            _clear_file_hash_cache = clear_file_hash_cache
+        except ImportError:
+            _clear_file_hash_cache = lambda **kw: False
+    return _clear_file_hash_cache
+
 
 # ---------------------------------------------------------------------------
 # Collection tracking
@@ -64,14 +77,22 @@ def ensure_collection(client: QdrantClient, name: str, dim: int, vector_name: st
                 has_sparse = sparse_cfg and LEX_SPARSE_NAME in (sparse_cfg if isinstance(sparse_cfg, dict) else {})
 
                 if LEX_SPARSE_MODE and not has_sparse:
-                    print(f"[COLLECTION_INFO] Collection {name} lacks sparse vector '{LEX_SPARSE_NAME}' - recreating...")
-                    backup_file = _backup_memories_before_recreate(name)
-                    try:
-                        client.delete_collection(name)
-                        print(f"[COLLECTION_INFO] Deleted existing collection {name}")
-                    except Exception:
-                        pass
-                    raise CollectionNeedsRecreateError(f"Collection {name} needs sparse vectors")
+                    # Guard: only auto-recreate if COLLECTION_AUTO_RECREATE=1
+                    auto_recreate = os.environ.get("COLLECTION_AUTO_RECREATE", "").strip().lower() in {
+                        "1", "true", "yes", "on",
+                    }
+                    if auto_recreate:
+                        print(f"[COLLECTION_INFO] Collection {name} lacks sparse vector '{LEX_SPARSE_NAME}' - recreating (COLLECTION_AUTO_RECREATE=1)...")
+                        backup_file = _backup_memories_before_recreate(name)
+                        try:
+                            client.delete_collection(name)
+                            print(f"[COLLECTION_INFO] Deleted existing collection {name}")
+                        except Exception:
+                            pass
+                        raise CollectionNeedsRecreateError(f"Collection {name} needs sparse vectors")
+                    else:
+                        print(f"[COLLECTION_WARNING] Collection {name} lacks sparse vector '{LEX_SPARSE_NAME}'. "
+                              f"Set COLLECTION_AUTO_RECREATE=1 to recreate, or disable LEX_SPARSE_MODE.")
 
                 missing = {}
                 if not has_lex:
@@ -115,14 +136,22 @@ def ensure_collection(client: QdrantClient, name: str, dim: int, vector_name: st
                         )
                         print(f"[COLLECTION_SUCCESS] Successfully updated collection {name} with missing vectors")
                     except Exception as update_e:
-                        print(f"[COLLECTION_WARNING] Cannot add missing vectors to {name} ({update_e}). Recreating collection...")
-                        backup_file = _backup_memories_before_recreate(name)
-                        try:
-                            client.delete_collection(name)
-                            print(f"[COLLECTION_INFO] Deleted existing collection {name}")
-                        except Exception:
-                            pass
-                        raise CollectionNeedsRecreateError(f"Collection {name} needs recreation for new vectors")
+                        # Guard: only auto-recreate if COLLECTION_AUTO_RECREATE=1
+                        auto_recreate = os.environ.get("COLLECTION_AUTO_RECREATE", "").strip().lower() in {
+                            "1", "true", "yes", "on",
+                        }
+                        if auto_recreate:
+                            print(f"[COLLECTION_WARNING] Cannot add missing vectors to {name} ({update_e}). Recreating collection (COLLECTION_AUTO_RECREATE=1)...")
+                            backup_file = _backup_memories_before_recreate(name)
+                            try:
+                                client.delete_collection(name)
+                                print(f"[COLLECTION_INFO] Deleted existing collection {name}")
+                            except Exception:
+                                pass
+                            raise CollectionNeedsRecreateError(f"Collection {name} needs recreation for new vectors")
+                        else:
+                            print(f"[COLLECTION_WARNING] Cannot add missing vectors to {name} ({update_e}). "
+                                  f"Set COLLECTION_AUTO_RECREATE=1 to recreate collection.")
         except CollectionNeedsRecreateError:
             print(f"[COLLECTION_INFO] Collection {name} needs recreation - proceeding...")
             raise
@@ -172,6 +201,17 @@ def ensure_collection(client: QdrantClient, name: str, dim: int, vector_name: st
     )
     sparse_info = f", sparse: [{LEX_SPARSE_NAME}]" if sparse_cfg else ""
     print(f"[COLLECTION_INFO] Successfully created new collection {name} with vectors: {list(vectors_cfg.keys())}{sparse_info}")
+
+    # Clear file hash cache to force re-indexing after collection recreation
+    # In multi-repo mode, only clear cache for repo(s) matching this collection
+    try:
+        clear_fn = _get_clear_file_hash_cache()
+        if clear_fn(collection_name=name):
+            print(f"[COLLECTION_INFO] File hash cache cleared for {name} - files will be re-indexed")
+        else:
+            print(f"[COLLECTION_INFO] No file hash cache found to clear for {name}")
+    except Exception as cache_e:
+        print(f"[COLLECTION_WARNING] Failed to clear file hash cache: {cache_e}")
 
     _restore_memories_after_recreate(name, backup_file)
 

--- a/scripts/workspace_state.py
+++ b/scripts/workspace_state.py
@@ -2278,6 +2278,75 @@ def clear_symbol_cache(
     return dirs_removed
 
 
+def clear_file_hash_cache(
+    workspace_path: Optional[str] = None,
+    repo_name: Optional[str] = None,
+    collection_name: Optional[str] = None,
+) -> bool:
+    """
+    Clear file hash cache for a workspace/repo.
+
+    This forces the indexer to re-index all files on the next run,
+    which is necessary after a collection is recreated.
+
+    Parameters:
+        workspace_path: Path to workspace root (default: auto-detect)
+        repo_name: Specific repo directory name to clear (multi-repo mode)
+        collection_name: Collection name to match - only clears cache for repos
+                        whose derived collection name matches (multi-repo mode)
+
+    Returns True if cache was cleared, False otherwise.
+    """
+    workspace_root = workspace_path or _resolve_workspace_root()
+
+    cache_paths: List[Path] = []
+
+    if is_multi_repo_mode():
+        if repo_name:
+            # Direct repo name specified
+            cache_paths.append(_get_repo_state_dir(repo_name) / CACHE_FILENAME)
+        elif collection_name:
+            # Find repo(s) whose collection name matches
+            repos_dir = Path(workspace_root) / STATE_DIRNAME / "repos"
+            if repos_dir.exists():
+                for repo_dir in repos_dir.iterdir():
+                    if not repo_dir.is_dir():
+                        continue
+                    try:
+                        # Compute the collection name for this repo
+                        repo_coll = _generate_collection_name_from_repo(repo_dir.name)
+                        if repo_coll == collection_name:
+                            cache_paths.append(repo_dir / CACHE_FILENAME)
+                    except Exception:
+                        pass
+        # If no specific target, don't clear anything in multi-repo mode
+        # (backwards compatible - don't nuke all caches)
+    else:
+        try:
+            cache_paths.append(_get_cache_path(workspace_root))
+        except Exception:
+            cache_paths.append(Path(workspace_root) / ".codebase" / CACHE_FILENAME)
+
+    cleared = False
+    for cache_path in cache_paths:
+        if not cache_path.exists():
+            continue
+        try:
+            cache = _read_cache_file_cached(cache_path)
+            if "file_hashes" in cache and cache["file_hashes"]:
+                cache["file_hashes"] = {}
+                cache["updated_at"] = datetime.now().isoformat()
+                cache["cleared_reason"] = "collection_recreated"
+                _atomic_write_state(cache_path, cache)
+                _memoize_cache_obj(cache_path, cache)
+                print(f"[CACHE_CLEAR] Cleared file hash cache at {cache_path}")
+                cleared = True
+        except Exception as e:
+            print(f"[CACHE_CLEAR_WARNING] Failed to clear cache at {cache_path}: {e}")
+
+    return cleared
+
+
 def compare_symbol_changes(old_symbols: dict, new_symbols: dict) -> tuple[list, list]:
     """
     Compare old and new symbols to identify changes.


### PR DESCRIPTION
Introduces a clear_file_hash_cache function in workspace_state.py to clear file hash caches when a Qdrant collection is recreated. Updates qdrant.py to call this function after collection recreation, ensuring files are re-indexed as needed. Also adds guards to only auto-recreate collections if COLLECTION_AUTO_RECREATE=1, providing safer collection management.