### PR TITLE
Improve thread safety and efficiency in search and memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         
     - name: Set environment variables
       run: |
-        echo "QDRANT_URL=http://localhost:6333" >> $GITHUB_ENV
+        # QDRANT_URL is hardcoded in tests/conftest.py for CI (detects CI=true)
         echo "COLLECTION_NAME=test-ci-${{ github.run_id }}" >> $GITHUB_ENV
         echo "PYTHONPATH=${{ github.workspace }}/scripts:$PYTHONPATH" >> $GITHUB_ENV
         

--- a/scripts/deduplication.py
+++ b/scripts/deduplication.py
@@ -12,7 +12,7 @@ import hashlib
 import threading
 import json
 from typing import Any, Dict, List, Optional, Tuple, Union
-from collections import defaultdict, deque
+from collections import defaultdict, OrderedDict
 import logging
 
 logger = logging.getLogger("deduplication")
@@ -130,7 +130,9 @@ class RequestDeduplicator:
         
         # Storage for request fingerprints
         self._fingerprints: Dict[str, RequestFingerprint] = {}
-        self._access_order = deque()  # For LRU tracking
+        # OrderedDict for O(1) LRU tracking (move_to_end, popitem)
+        # Keys track access order; values are timestamps for debugging
+        self._access_order: OrderedDict[str, float] = OrderedDict()
         
         # Thread safety
         self._lock = threading.RLock()
@@ -281,24 +283,21 @@ class RequestDeduplicator:
             # Delete under the same lock
             for key in expired_keys:
                 self._fingerprints.pop(key, None)
-                # Remove from access order
-                try:
-                    self._access_order.remove(key)
-                except ValueError:
-                    pass
+                # Remove from access order (O(1) with OrderedDict)
+                self._access_order.pop(key, None)
 
         if expired_keys:
             logger.debug(f"Cleaned up {len(expired_keys)} expired request fingerprints")
-    
+
     def _evict_if_needed(self) -> None:
         """Evict oldest entries if cache is full."""
         with self._lock:
             while len(self._fingerprints) >= self.max_cache_size:
                 try:
-                    oldest_key = self._access_order.popleft()
-                    if oldest_key in self._fingerprints:
-                        del self._fingerprints[oldest_key]
-                except (IndexError, KeyError):
+                    # popitem(last=False) removes oldest entry in O(1)
+                    oldest_key, _ = self._access_order.popitem(last=False)
+                    self._fingerprints.pop(oldest_key, None)
+                except KeyError:
                     break
     
     def is_duplicate(self, request_data: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
@@ -319,14 +318,8 @@ class RequestDeduplicator:
             # Synchronous TTL cleanup to avoid stale matches in tight loops
             expired_keys = [k for k, fp in self._fingerprints.items() if fp.is_expired(self.dedup_window_seconds)]
             for k in expired_keys:
-                try:
-                    del self._fingerprints[k]
-                    try:
-                        self._access_order.remove(k)
-                    except ValueError:
-                        pass
-                except Exception:
-                    pass
+                self._fingerprints.pop(k, None)
+                self._access_order.pop(k, None)  # O(1) with OrderedDict
             if expired_keys:
                 # Keep cache_size accurate after purge
                 self._stats['cache_size'] = len(self._fingerprints)
@@ -343,12 +336,11 @@ class RequestDeduplicator:
                 # Update access statistics
                 self._fingerprints[similar_fp].access()
 
-                # Update access order for LRU
-                try:
-                    self._access_order.remove(similar_fp)
-                    self._access_order.append(similar_fp)
-                except ValueError:
-                    self._access_order.append(similar_fp)
+                # Update access order for LRU (O(1) with move_to_end)
+                if similar_fp in self._access_order:
+                    self._access_order.move_to_end(similar_fp)
+                else:
+                    self._access_order[similar_fp] = time.time()
 
                 self._stats['deduped_requests'] += 1
                 self._stats['cache_hits'] += 1
@@ -361,7 +353,7 @@ class RequestDeduplicator:
 
                 # Store new fingerprint
                 self._fingerprints[candidate_fp] = candidate_obj
-                self._access_order.append(candidate_fp)
+                self._access_order[candidate_fp] = time.time()
 
                 self._stats['unique_requests'] += 1
                 self._stats['cache_size'] = len(self._fingerprints)

--- a/scripts/deduplication.py
+++ b/scripts/deduplication.py
@@ -265,23 +265,28 @@ class RequestDeduplicator:
                 logger.error(f"Deduplication cleanup error: {e}")
     
     def _cleanup_expired(self) -> None:
-        """Clean up expired request fingerprints."""
-        current_time = time.time()
+        """Clean up expired request fingerprints.
+
+        Thread-safe: holds lock during both iteration and deletion to avoid
+        'dict changed size during iteration' race conditions.
+        """
         expired_keys = []
-        
-        for key, fp in self._fingerprints.items():
-            if fp.is_expired(self.dedup_window_seconds):
-                expired_keys.append(key)
-        
+
         with self._lock:
+            # Iterate under lock to avoid race with concurrent modifications
+            for key, fp in list(self._fingerprints.items()):
+                if fp.is_expired(self.dedup_window_seconds):
+                    expired_keys.append(key)
+
+            # Delete under the same lock
             for key in expired_keys:
-                del self._fingerprints[key]
+                self._fingerprints.pop(key, None)
                 # Remove from access order
                 try:
                     self._access_order.remove(key)
                 except ValueError:
                     pass
-        
+
         if expired_keys:
             logger.debug(f"Cleaned up {len(expired_keys)} expired request fingerprints")
     

--- a/scripts/embedder.py
+++ b/scripts/embedder.py
@@ -235,3 +235,28 @@ def get_model_dimension(model_name: Optional[str] = None) -> int:
     # Default: BGE-base and similar 768-dimension models
     return 768
 
+
+def is_model_cached(model_name: Optional[str] = None) -> bool:
+    """Check if an embedding model is already loaded in the cache.
+
+    This is useful for cold-start detection to avoid blocking on model loading.
+
+    Args:
+        model_name: Model name to check. If None, uses EMBEDDING_MODEL env var.
+
+    Returns:
+        True if the model is already cached, False otherwise.
+    """
+    if model_name is None:
+        model_name = os.environ.get("EMBEDDING_MODEL", DEFAULT_MODEL)
+    return model_name in _EMBED_MODEL_CACHE
+
+
+def get_cached_models() -> List[str]:
+    """Get list of currently cached model names.
+
+    Returns:
+        List of model names currently in the cache.
+    """
+    return list(_EMBED_MODEL_CACHE.keys())
+

--- a/scripts/hybrid_search.py
+++ b/scripts/hybrid_search.py
@@ -354,7 +354,44 @@ def run_hybrid_search(
     repo: str | list[str] | None = None,  # Filter by repo name(s); "*" to disable auto-filter
     per_query: int | None = None,  # Base candidate retrieval per query (default: adaptive)
 ) -> List[Dict[str, Any]]:
-    client = QdrantClient(url=os.environ.get("QDRANT_URL", QDRANT_URL), api_key=API_KEY)
+    # Use pooled client instead of creating a new one per request
+    client = get_qdrant_client(
+        url=os.environ.get("QDRANT_URL", QDRANT_URL),
+        api_key=API_KEY
+    )
+    try:
+        return _run_hybrid_search_impl(
+            client, queries, limit, per_path, language, under, kind, symbol, ext,
+            not_filter, case, path_regex, path_glob, not_glob, expand, model,
+            collection, mode, repo, per_query
+        )
+    finally:
+        return_qdrant_client(client)
+
+
+def _run_hybrid_search_impl(
+    client: QdrantClient,
+    queries: List[str],
+    limit: int,
+    per_path: int,
+    language: str | None,
+    under: str | None,
+    kind: str | None,
+    symbol: str | None,
+    ext: str | None,
+    not_filter: str | None,
+    case: str | None,
+    path_regex: str | None,
+    path_glob: str | list[str] | None,
+    not_glob: str | list[str] | None,
+    expand: bool,
+    model: Any,
+    collection: str | None,
+    mode: str | None,
+    repo: str | list[str] | None,
+    per_query: int | None,
+) -> List[Dict[str, Any]]:
+    """Internal implementation of hybrid search with provided client."""
     model_name = os.environ.get("EMBEDDING_MODEL", MODEL_NAME)
     if model:
         _model = model
@@ -1433,6 +1470,35 @@ def run_hybrid_search(
 
     import io as _io
 
+    # File content cache to avoid re-reading files for each snippet
+    # Guarded by HYBRID_SNIPPET_DISK_READ env var (default OFF in production)
+    _file_lines_cache: Dict[str, List[str]] = {}
+    _snippet_disk_reads = os.environ.get("HYBRID_SNIPPET_DISK_READ", "0").strip().lower() in {
+        "1", "true", "yes", "on"
+    }
+
+    def _get_file_lines(path: str) -> List[str]:
+        """Get file lines with caching to avoid repeated disk reads."""
+        if path in _file_lines_cache:
+            return _file_lines_cache[path]
+        if not _snippet_disk_reads:
+            return []  # Disk reads disabled
+        try:
+            p = path
+            if not os.path.isabs(p):
+                p = os.path.join("/work", p)
+            realp = os.path.realpath(p)
+            if realp == "/work" or realp.startswith("/work/"):
+                with open(realp, "r", encoding="utf-8", errors="ignore") as f:
+                    lines = f.readlines()
+                # Limit cache size to avoid memory issues
+                if len(_file_lines_cache) < 100:
+                    _file_lines_cache[path] = lines
+                return lines
+        except Exception:
+            pass
+        return []
+
     def _snippet_contains(md: dict) -> int:
         # returns number of keyword hits found in a small local snippet
         try:
@@ -1441,19 +1507,11 @@ def run_hybrid_search(
             eline = int(md.get("end_line") or 0)
             txt = (md.get("text") or md.get("code") or "")
             if not txt and path and sline:
-                p = path
-                try:
-                    if not os.path.isabs(p):
-                        p = os.path.join("/work", p)
-                    realp = os.path.realpath(p)
-                    if realp == "/work" or realp.startswith("/work/"):
-                        with open(realp, "r", encoding="utf-8", errors="ignore") as f:
-                            lines = f.readlines()
-                        si = max(1, sline - 3)
-                        ei = min(len(lines), max(sline, eline) + 3)
-                        txt = "".join(lines[si-1:ei])
-                except Exception:
-                    txt = txt or ""
+                lines = _get_file_lines(path)
+                if lines:
+                    si = max(1, sline - 3)
+                    ei = min(len(lines), max(sline, eline) + 3)
+                    txt = "".join(lines[si-1:ei])
             lt = (txt or "").lower()
             if not lt:
                 return 0
@@ -1473,19 +1531,11 @@ def run_hybrid_search(
             eline = int(md.get("end_line") or 0)
             txt = (md.get("text") or md.get("code") or "")
             if not txt and path and sline:
-                p = path
-                try:
-                    if not os.path.isabs(p):
-                        p = os.path.join("/work", p)
-                    realp = os.path.realpath(p)
-                    if realp == "/work" or realp.startswith("/work/"):
-                        with open(realp, "r", encoding="utf-8", errors="ignore") as f:
-                            lines = f.readlines()
-                        si = max(1, sline - 3)
-                        ei = min(len(lines), max(sline, eline) + 3)
-                        txt = "".join(lines[si-1:ei])
-                except Exception:
-                    txt = txt or ""
+                lines = _get_file_lines(path)
+                if lines:
+                    si = max(1, sline - 3)
+                    ei = min(len(lines), max(sline, eline) + 3)
+                    txt = "".join(lines[si-1:ei])
             if not txt:
                 return 0.0
             total = 0

--- a/scripts/hybrid_search.py
+++ b/scripts/hybrid_search.py
@@ -1467,26 +1467,37 @@ def _run_hybrid_search_impl(
     }
 
     def _get_file_lines(path: str) -> List[str]:
-        """Get file lines with LRU caching to avoid repeated disk reads."""
-        with _file_lines_cache_lock:
-            if path in _file_lines_cache:
-                # Move to end for LRU ordering
-                _file_lines_cache.move_to_end(path)
-                return _file_lines_cache[path]
-        if not _snippet_disk_reads:
-            return []  # Disk reads disabled
+        """Get file lines with LRU caching to avoid repeated disk reads.
+
+        Cache key is normalized to realpath to prevent duplicate entries
+        for the same file accessed via different path forms.
+        """
+        # Normalize path for consistent cache keys
+        p = path
+        if not os.path.isabs(p):
+            p = os.path.join("/work", p)
         try:
-            p = path
-            if not os.path.isabs(p):
-                p = os.path.join("/work", p)
-            realp = os.path.realpath(p)
-            if realp == "/work" or realp.startswith("/work/"):
-                with open(realp, "r", encoding="utf-8", errors="ignore") as f:
+            cache_key = os.path.realpath(p)
+        except Exception:
+            cache_key = p  # Fallback if realpath fails
+
+        with _file_lines_cache_lock:
+            if cache_key in _file_lines_cache:
+                # Move to end for LRU ordering
+                _file_lines_cache.move_to_end(cache_key)
+                return _file_lines_cache[cache_key]
+
+        if not _snippet_disk_reads:
+            return []  # Disk reads disabled; caller should handle empty gracefully
+
+        try:
+            if cache_key == "/work" or cache_key.startswith("/work/"):
+                with open(cache_key, "r", encoding="utf-8", errors="ignore") as f:
                     lines = f.readlines()
                 # LRU eviction: remove oldest entries when at capacity
                 with _file_lines_cache_lock:
-                    _file_lines_cache[path] = lines
-                    _file_lines_cache.move_to_end(path)
+                    _file_lines_cache[cache_key] = lines
+                    _file_lines_cache.move_to_end(cache_key)
                     while len(_file_lines_cache) > _FILE_LINES_CACHE_MAX:
                         try:
                             _file_lines_cache.popitem(last=False)

--- a/scripts/hybrid_search.py
+++ b/scripts/hybrid_search.py
@@ -1496,7 +1496,7 @@ def _run_hybrid_search_impl(
                     _file_lines_cache[path] = lines
                 return lines
         except Exception:
-            pass
+            logging.debug("Failed to read file for snippet lines: %s", path, exc_info=True)
         return []
 
     def _snippet_contains(md: dict) -> int:

--- a/scripts/hybrid_search.py
+++ b/scripts/hybrid_search.py
@@ -548,22 +548,15 @@ def _run_hybrid_search_impl(
                     if os.environ.get("DEBUG_HYBRID_SEARCH"):
                         logger.debug("cache hit for hybrid results (unified)")
                     return val
-                # Fallback to local in-process dict to ensure deterministic hits (esp. in unit tests)
-                try:
-                    with _RESULTS_LOCK:
-                        if cache_key in _RESULTS_CACHE_OD:
-                            if os.environ.get("DEBUG_HYBRID_SEARCH"):
-                                logger.debug("cache hit for hybrid results (fallback OD)")
-                            return _RESULTS_CACHE_OD[cache_key]
-                except Exception:
-                    pass
             else:
+                # Local OrderedDict fallback when unified cache not available
                 with _RESULTS_LOCK:
-                    if cache_key in _RESULTS_CACHE:
-                        val = _RESULTS_CACHE.pop(cache_key)
-                        _RESULTS_CACHE[cache_key] = val
+                    if cache_key in _RESULTS_CACHE_OD:
+                        # Move to end for LRU behavior
+                        val = _RESULTS_CACHE_OD.pop(cache_key)
+                        _RESULTS_CACHE_OD[cache_key] = val
                         if os.environ.get("DEBUG_HYBRID_SEARCH"):
-                            logger.debug("cache hit for hybrid results (legacy)")
+                            logger.debug("cache hit for hybrid results (local)")
                         return val
 
     # Build optional filter
@@ -646,21 +639,13 @@ def _run_hybrid_search_impl(
                         if os.environ.get("DEBUG_HYBRID_SEARCH"):
                             logger.debug("duplicate served from cache (unified)")
                         return val
-                    try:
-                        with _RESULTS_LOCK:
-                            if cache_key in _RESULTS_CACHE_OD:
-                                if os.environ.get("DEBUG_HYBRID_SEARCH"):
-                                    logger.debug("duplicate served from cache (fallback OD)")
-                                return _RESULTS_CACHE_OD[cache_key]
-                    except Exception:
-                        pass
                 else:
                     with _RESULTS_LOCK:
-                        if cache_key in _RESULTS_CACHE:
-                            val = _RESULTS_CACHE.pop(cache_key)
-                            _RESULTS_CACHE[cache_key] = val
+                        if cache_key in _RESULTS_CACHE_OD:
+                            val = _RESULTS_CACHE_OD.pop(cache_key)
+                            _RESULTS_CACHE_OD[cache_key] = val
                             if os.environ.get("DEBUG_HYBRID_SEARCH"):
-                                logger.debug("duplicate served from cache (legacy)")
+                                logger.debug("duplicate served from cache (local)")
                             return val
             if os.environ.get("DEBUG_HYBRID_SEARCH"):
                 logger.debug("Duplicate without cache; bypassing dedup and continuing search")
@@ -1469,18 +1454,25 @@ def _run_hybrid_search_impl(
                 kw.add(t)
 
     import io as _io
+    from collections import OrderedDict as _FileCacheOD
 
     # File content cache to avoid re-reading files for each snippet
     # Controlled by HYBRID_SNIPPET_DISK_READ env var (default ON for backwards compatibility)
-    _file_lines_cache: Dict[str, List[str]] = {}
+    # Uses OrderedDict for LRU eviction to bound memory usage
+    _FILE_LINES_CACHE_MAX = int(os.environ.get("HYBRID_FILE_CACHE_MAX", "100") or 100)
+    _file_lines_cache: _FileCacheOD[str, List[str]] = _FileCacheOD()
+    _file_lines_cache_lock = threading.Lock()
     _snippet_disk_reads = os.environ.get("HYBRID_SNIPPET_DISK_READ", "1").strip().lower() not in {
         "0", "false", "no", "off"
     }
 
     def _get_file_lines(path: str) -> List[str]:
-        """Get file lines with caching to avoid repeated disk reads."""
-        if path in _file_lines_cache:
-            return _file_lines_cache[path]
+        """Get file lines with LRU caching to avoid repeated disk reads."""
+        with _file_lines_cache_lock:
+            if path in _file_lines_cache:
+                # Move to end for LRU ordering
+                _file_lines_cache.move_to_end(path)
+                return _file_lines_cache[path]
         if not _snippet_disk_reads:
             return []  # Disk reads disabled
         try:
@@ -1491,9 +1483,15 @@ def _run_hybrid_search_impl(
             if realp == "/work" or realp.startswith("/work/"):
                 with open(realp, "r", encoding="utf-8", errors="ignore") as f:
                     lines = f.readlines()
-                # Limit cache size to avoid memory issues
-                if len(_file_lines_cache) < 100:
+                # LRU eviction: remove oldest entries when at capacity
+                with _file_lines_cache_lock:
                     _file_lines_cache[path] = lines
+                    _file_lines_cache.move_to_end(path)
+                    while len(_file_lines_cache) > _FILE_LINES_CACHE_MAX:
+                        try:
+                            _file_lines_cache.popitem(last=False)
+                        except KeyError:
+                            break
                 return lines
         except Exception:
             logging.debug("Failed to read file for snippet lines: %s", path, exc_info=True)
@@ -1981,28 +1979,21 @@ def _run_hybrid_search_impl(
         items.append(item)
     if _USE_CACHE and cache_key is not None:
         if UNIFIED_CACHE_AVAILABLE:
+            # Use unified cache only - no duplication to local fallback
             _RESULTS_CACHE.set(cache_key, items)
-            # Mirror into local fallback dict for deterministic hits in tests
-            try:
-                with _RESULTS_LOCK:
-                    _RESULTS_CACHE_OD[cache_key] = items
-                    while len(_RESULTS_CACHE_OD) > MAX_RESULTS_CACHE:
-                        # pop oldest inserted (like LRU/FIFO)
-                        try:
-                            _RESULTS_CACHE_OD.popitem(last=False)
-                        except Exception:
-                            break
-            except Exception:
-                pass
             if os.environ.get("DEBUG_HYBRID_SEARCH"):
-                logger.debug("cache store for hybrid results")
+                logger.debug("cache store for hybrid results (unified)")
         else:
+            # Fallback to local OrderedDict when unified cache not available
             with _RESULTS_LOCK:
-                _RESULTS_CACHE[cache_key] = items
+                _RESULTS_CACHE_OD[cache_key] = items
+                while len(_RESULTS_CACHE_OD) > MAX_RESULTS_CACHE:
+                    try:
+                        _RESULTS_CACHE_OD.popitem(last=False)
+                    except Exception:
+                        break
                 if os.environ.get("DEBUG_HYBRID_SEARCH"):
-                    logger.debug("cache store for hybrid results")
-                while len(_RESULTS_CACHE) > MAX_RESULTS_CACHE:
-                    _RESULTS_CACHE.popitem(last=False)
+                    logger.debug("cache store for hybrid results (local)")
     return items
 
 

--- a/scripts/hybrid_search.py
+++ b/scripts/hybrid_search.py
@@ -1471,10 +1471,10 @@ def _run_hybrid_search_impl(
     import io as _io
 
     # File content cache to avoid re-reading files for each snippet
-    # Guarded by HYBRID_SNIPPET_DISK_READ env var (default OFF in production)
+    # Controlled by HYBRID_SNIPPET_DISK_READ env var (default ON for backwards compatibility)
     _file_lines_cache: Dict[str, List[str]] = {}
-    _snippet_disk_reads = os.environ.get("HYBRID_SNIPPET_DISK_READ", "0").strip().lower() in {
-        "1", "true", "yes", "on"
+    _snippet_disk_reads = os.environ.get("HYBRID_SNIPPET_DISK_READ", "1").strip().lower() not in {
+        "0", "false", "no", "off"
     }
 
     def _get_file_lines(path: str) -> List[str]:

--- a/scripts/ingest/qdrant.py
+++ b/scripts/ingest/qdrant.py
@@ -32,6 +32,30 @@ from scripts.ingest.config import (
 ENSURED_COLLECTIONS: set[str] = set()
 ENSURED_COLLECTIONS_LAST_CHECK: dict[str, float] = {}
 
+# TTL for ensured collections cache (default 1 hour). After TTL expires, entries are
+# eligible for eviction to bound memory in long-running processes with many collections.
+ENSURED_COLLECTIONS_TTL = float(os.environ.get("ENSURED_COLLECTIONS_TTL", "3600") or 3600)
+# Maximum number of collections to track (prevents unbounded growth)
+ENSURED_COLLECTIONS_MAX = int(os.environ.get("ENSURED_COLLECTIONS_MAX", "500") or 500)
+
+
+def _cleanup_stale_ensured_collections() -> int:
+    """Remove stale entries from ENSURED_COLLECTIONS based on TTL.
+
+    Returns number of entries removed.
+    """
+    if not ENSURED_COLLECTIONS_LAST_CHECK:
+        return 0
+    now = time.time()
+    stale = []
+    for coll, last_check in list(ENSURED_COLLECTIONS_LAST_CHECK.items()):
+        if (now - last_check) > ENSURED_COLLECTIONS_TTL:
+            stale.append(coll)
+    for coll in stale:
+        ENSURED_COLLECTIONS.discard(coll)
+        ENSURED_COLLECTIONS_LAST_CHECK.pop(coll, None)
+    return len(stale)
+
 
 class CollectionNeedsRecreateError(Exception):
     """Raised when a collection needs to be recreated to add new vector types."""
@@ -341,9 +365,17 @@ def ensure_collection_and_indexes_once(
     dim: int,
     vector_name: str | None,
 ) -> None:
-    """Ensure collection and indexes exist (cached per-process)."""
+    """Ensure collection and indexes exist (cached per-process).
+
+    Periodically cleans up stale entries based on TTL to prevent unbounded growth.
+    """
     if not collection:
         return
+
+    # Periodic cleanup: remove stale entries when cache is large
+    if len(ENSURED_COLLECTIONS) > ENSURED_COLLECTIONS_MAX // 2:
+        _cleanup_stale_ensured_collections()
+
     if collection in ENSURED_COLLECTIONS:
         try:
             ping_seconds = float(os.environ.get("ENSURED_COLLECTION_PING_SECONDS", "0") or 0)
@@ -370,6 +402,24 @@ def ensure_collection_and_indexes_once(
                 ENSURED_COLLECTIONS_LAST_CHECK.pop(collection, None)
             except Exception:
                 pass
+
+    # Enforce max size: evict oldest entries if at capacity
+    while len(ENSURED_COLLECTIONS) >= ENSURED_COLLECTIONS_MAX:
+        _cleanup_stale_ensured_collections()
+        if len(ENSURED_COLLECTIONS) >= ENSURED_COLLECTIONS_MAX:
+            # Still at capacity after cleanup - evict oldest
+            oldest_coll = None
+            oldest_time = float('inf')
+            for c, t in ENSURED_COLLECTIONS_LAST_CHECK.items():
+                if t < oldest_time:
+                    oldest_time = t
+                    oldest_coll = c
+            if oldest_coll:
+                ENSURED_COLLECTIONS.discard(oldest_coll)
+                ENSURED_COLLECTIONS_LAST_CHECK.pop(oldest_coll, None)
+            else:
+                break  # Safety: avoid infinite loop
+
     ensure_collection(client, collection, dim, vector_name)
     ensure_payload_indexes(client, collection)
     ENSURED_COLLECTIONS.add(collection)

--- a/scripts/ingest/qdrant.py
+++ b/scripts/ingest/qdrant.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import time
 import hashlib
+import threading
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 
@@ -27,8 +28,9 @@ from scripts.ingest.config import (
 
 
 # ---------------------------------------------------------------------------
-# Collection tracking
+# Collection tracking (thread-safe)
 # ---------------------------------------------------------------------------
+_ensured_lock = threading.Lock()
 ENSURED_COLLECTIONS: set[str] = set()
 ENSURED_COLLECTIONS_LAST_CHECK: dict[str, float] = {}
 
@@ -39,10 +41,12 @@ ENSURED_COLLECTIONS_TTL = float(os.environ.get("ENSURED_COLLECTIONS_TTL", "3600"
 ENSURED_COLLECTIONS_MAX = int(os.environ.get("ENSURED_COLLECTIONS_MAX", "500") or 500)
 
 
-def _cleanup_stale_ensured_collections() -> int:
+def _cleanup_stale_ensured_collections_unlocked() -> int:
     """Remove stale entries from ENSURED_COLLECTIONS based on TTL.
 
     Returns number of entries removed.
+
+    NOTE: Caller MUST hold _ensured_lock before calling this function.
     """
     if not ENSURED_COLLECTIONS_LAST_CHECK:
         return 0
@@ -367,66 +371,80 @@ def ensure_collection_and_indexes_once(
 ) -> None:
     """Ensure collection and indexes exist (cached per-process).
 
+    Thread-safe: uses _ensured_lock to protect cache mutations.
     Periodically cleans up stale entries based on TTL to prevent unbounded growth.
     """
     if not collection:
         return
 
-    # Periodic cleanup: remove stale entries when cache is large
-    if len(ENSURED_COLLECTIONS) > ENSURED_COLLECTIONS_MAX // 2:
-        _cleanup_stale_ensured_collections()
+    # Fast path: check if already ensured (read under lock for consistency)
+    with _ensured_lock:
+        if collection in ENSURED_COLLECTIONS:
+            try:
+                ping_seconds = float(os.environ.get("ENSURED_COLLECTION_PING_SECONDS", "0") or 0)
+            except Exception:
+                ping_seconds = 0.0
 
-    if collection in ENSURED_COLLECTIONS:
-        try:
-            ping_seconds = float(os.environ.get("ENSURED_COLLECTION_PING_SECONDS", "0") or 0)
-        except Exception:
-            ping_seconds = 0.0
+            if ping_seconds <= 0:
+                return
 
-        if ping_seconds <= 0:
-            return
-
-        try:
             now = time.time()
             last = ENSURED_COLLECTIONS_LAST_CHECK.get(collection, 0.0)
             if (now - last) < ping_seconds:
                 return
+            # Need to ping - release lock for network call
+            need_ping = True
+        else:
+            need_ping = False
+
+    # Ping outside lock to avoid holding lock during network I/O
+    if need_ping:
+        try:
             client.get_collection(collection)
-            ENSURED_COLLECTIONS_LAST_CHECK[collection] = now
+            with _ensured_lock:
+                ENSURED_COLLECTIONS_LAST_CHECK[collection] = time.time()
             return
         except Exception:
-            try:
+            with _ensured_lock:
                 ENSURED_COLLECTIONS.discard(collection)
-            except Exception:
-                pass
-            try:
                 ENSURED_COLLECTIONS_LAST_CHECK.pop(collection, None)
-            except Exception:
-                pass
+            # Fall through to re-ensure
 
-    # Enforce max size: evict oldest entries if at capacity
-    while len(ENSURED_COLLECTIONS) >= ENSURED_COLLECTIONS_MAX:
-        _cleanup_stale_ensured_collections()
-        if len(ENSURED_COLLECTIONS) >= ENSURED_COLLECTIONS_MAX:
-            # Still at capacity after cleanup - evict oldest
-            oldest_coll = None
-            oldest_time = float('inf')
-            for c, t in ENSURED_COLLECTIONS_LAST_CHECK.items():
-                if t < oldest_time:
-                    oldest_time = t
-                    oldest_coll = c
-            if oldest_coll:
-                ENSURED_COLLECTIONS.discard(oldest_coll)
-                ENSURED_COLLECTIONS_LAST_CHECK.pop(oldest_coll, None)
-            else:
-                break  # Safety: avoid infinite loop
+    # Slow path: need to ensure collection exists
+    with _ensured_lock:
+        # Double-check after acquiring lock (another thread may have ensured it)
+        if collection in ENSURED_COLLECTIONS:
+            return
 
+        # Periodic cleanup: remove stale entries when cache is large
+        if len(ENSURED_COLLECTIONS) > ENSURED_COLLECTIONS_MAX // 2:
+            _cleanup_stale_ensured_collections_unlocked()
+
+        # Enforce max size: evict oldest entries if at capacity
+        while len(ENSURED_COLLECTIONS) >= ENSURED_COLLECTIONS_MAX:
+            _cleanup_stale_ensured_collections_unlocked()
+            if len(ENSURED_COLLECTIONS) >= ENSURED_COLLECTIONS_MAX:
+                # Still at capacity after cleanup - evict oldest
+                oldest_coll = None
+                oldest_time = float('inf')
+                for c, t in ENSURED_COLLECTIONS_LAST_CHECK.items():
+                    if t < oldest_time:
+                        oldest_time = t
+                        oldest_coll = c
+                if oldest_coll:
+                    ENSURED_COLLECTIONS.discard(oldest_coll)
+                    ENSURED_COLLECTIONS_LAST_CHECK.pop(oldest_coll, None)
+                else:
+                    break  # Safety: avoid infinite loop
+
+    # Create collection outside lock to avoid holding lock during network I/O
     ensure_collection(client, collection, dim, vector_name)
     ensure_payload_indexes(client, collection)
-    ENSURED_COLLECTIONS.add(collection)
-    try:
+
+    # Mark as ensured
+    with _ensured_lock:
+        ENSURED_COLLECTIONS.add(collection)
         ENSURED_COLLECTIONS_LAST_CHECK[collection] = time.time()
-    except Exception:
-        pass
 
 
 def get_indexed_file_hash(

--- a/scripts/mcp_impl/context_answer.py
+++ b/scripts/mcp_impl/context_answer.py
@@ -2659,9 +2659,9 @@ async def _context_answer_impl(
     original_queries = list(queries)
 
     try:
-        # Enable ReFRAG gate-first for context compression
-        os.environ["REFRAG_MODE"] = "1"
-        os.environ["REFRAG_GATE_FIRST"] = os.environ.get("REFRAG_GATE_FIRST", "1") or "1"
+        # Enable ReFRAG gate-first for context compression (use setdefault to respect explicit overrides)
+        os.environ.setdefault("REFRAG_MODE", "1")
+        os.environ.setdefault("REFRAG_GATE_FIRST", "1")
         os.environ["COLLECTION_NAME"] = coll
         if budget_tokens is not None and str(budget_tokens).strip() != "":
             os.environ["MICRO_BUDGET_TOKENS"] = str(budget_tokens)

--- a/scripts/mcp_indexer_server.py
+++ b/scripts/mcp_indexer_server.py
@@ -267,7 +267,8 @@ MCP_TOOL_TIMEOUT_SECS = safe_float(
 )
 
 # Set default environment variables for context_answer functionality
-os.environ.setdefault("DEBUG_CONTEXT_ANSWER", "1")
+# DEBUG_CONTEXT_ANSWER defaults to 0 for production; enable explicitly if needed
+os.environ.setdefault("DEBUG_CONTEXT_ANSWER", "0")
 os.environ.setdefault("REFRAG_DECODER", "1")
 os.environ.setdefault("LLAMACPP_URL", "http://localhost:8080")
 os.environ.setdefault("USE_GPU_DECODER", "0")

--- a/scripts/mcp_memory_server.py
+++ b/scripts/mcp_memory_server.py
@@ -461,7 +461,9 @@ def memory_store(
     point = models.PointStruct(
         id=pid, vector={VECTOR_NAME: dense, LEX_VECTOR_NAME: lex}, payload=payload
     )
-    client.upsert(collection_name=coll, points=[point], wait=True)
+    # wait=True blocks until Qdrant confirms write; set MEMORY_UPSERT_WAIT=0 for async writes
+    _upsert_wait = os.environ.get("MEMORY_UPSERT_WAIT", "1").strip().lower() in {"1", "true", "yes", "on"}
+    client.upsert(collection_name=coll, points=[point], wait=_upsert_wait)
     return {
         "ok": True,
         "id": pid,

--- a/scripts/mcp_memory_server.py
+++ b/scripts/mcp_memory_server.py
@@ -40,6 +40,17 @@ from scripts.mcp_auth import (
 
 from qdrant_client import QdrantClient, models
 
+# Import connection pooling for proper resource management
+try:
+    from scripts.qdrant_client_manager import (
+        get_qdrant_client,
+        return_qdrant_client,
+        pooled_qdrant_client,
+    )
+    _POOL_AVAILABLE = True
+except ImportError:
+    _POOL_AVAILABLE = False
+
 # Env
 QDRANT_URL = os.environ.get("QDRANT_URL", "http://qdrant:6333")
 DEFAULT_COLLECTION = (
@@ -72,40 +83,35 @@ try:
 except Exception:
     MEMORY_VECTOR_DIM = 768
 
-# Lazy embedding model cache with double-checked locking.
-# RATIONALE: Avoid loading the embedding model (100–500 MB) on module import.
-# On slow storage (Ceph + HDD), eager loading can cause 30–60s startup delays.
-# Instead, load on first tool call (store/find). Subsequent calls reuse cached instance.
-_EMBED_MODEL_CACHE: Dict[str, Any] = {}
-_EMBED_MODEL_LOCK = threading.Lock()
+# ---------------------------------------------------------------------------
+# Embedding Model Management
+# ---------------------------------------------------------------------------
+# Use the centralized embedder from scripts.embedder for consistent caching.
+# This eliminates duplicate model loading and ensures consistent behavior.
+
+# Reference to the centralized cache for cold-skip detection
+try:
+    from scripts.embedder import get_embedding_model as _centralized_get_embedding_model
+    from scripts.embedder import _EMBED_MODEL_CACHE
+    _EMBEDDER_AVAILABLE = True
+except ImportError:
+    _EMBEDDER_AVAILABLE = False
+    _EMBED_MODEL_CACHE: Dict[str, Any] = {}  # Fallback empty cache
 
 def _get_embedding_model():
-    """Lazily load and cache the embedding model to avoid startup I/O.
+    """Get the embedding model using the centralized embedder.
 
-    Uses the centralized embedder factory if available, with fallback
-    to direct fastembed initialization for backwards compatibility.
+    Uses scripts.embedder.get_embedding_model() which provides:
+    - Thread-safe lazy loading with double-checked locking
+    - Qwen3 model support with feature flags
+    - Automatic cache invalidation on corrupted downloads
     """
-    # Try centralized embedder factory first (supports Qwen3 feature flag)
-    try:
-        from scripts.embedder import get_embedding_model
-        return get_embedding_model(EMBEDDING_MODEL)
-    except ImportError:
-        pass
+    if _EMBEDDER_AVAILABLE:
+        return _centralized_get_embedding_model(EMBEDDING_MODEL)
 
-    # Fallback to original implementation
+    # Fallback for environments without centralized embedder (rare)
     from fastembed import TextEmbedding
-    m = _EMBED_MODEL_CACHE.get(EMBEDDING_MODEL)
-    if m is None:
-        with _EMBED_MODEL_LOCK:
-            m = _EMBED_MODEL_CACHE.get(EMBEDDING_MODEL)
-            if m is None:
-                m = TextEmbedding(model_name=EMBEDDING_MODEL)
-                try:
-                    _ = next(m.embed(["warmup"]))
-                except Exception:
-                    pass
-                _EMBED_MODEL_CACHE[EMBEDDING_MODEL] = m
-    return m
+    return TextEmbedding(model_name=EMBEDDING_MODEL)
 
 # Track ensured collections to reduce redundant ensure calls.
 # RATIONALE: Avoid repeated Qdrant network calls for the same collection.
@@ -253,7 +259,27 @@ def _start_readyz_server():
         return False
 
 
-client = QdrantClient(url=QDRANT_URL, api_key=os.environ.get("QDRANT_API_KEY"))
+# ---------------------------------------------------------------------------
+# Qdrant Client Management
+# ---------------------------------------------------------------------------
+# Use connection pooling when available, fallback to creating clients on-demand.
+# This prevents socket exhaustion under load and improves connection reuse.
+
+def _get_qdrant_client() -> QdrantClient:
+    """Get a Qdrant client from pool or create one."""
+    if _POOL_AVAILABLE:
+        return get_qdrant_client(
+            url=QDRANT_URL,
+            api_key=os.environ.get("QDRANT_API_KEY")
+        )
+    return QdrantClient(url=QDRANT_URL, api_key=os.environ.get("QDRANT_API_KEY"))
+
+
+def _return_qdrant_client(client: QdrantClient):
+    """Return a client to the pool (no-op if pooling unavailable)."""
+    if _POOL_AVAILABLE and client is not None:
+        return_qdrant_client(client)
+
 
 # Ensure collection exists with dual vectors
 
@@ -269,11 +295,14 @@ def _ensure_collection(name: str):
     - MEMORY_PROBE_EMBED_DIM=0  -> skip model probing; use MEMORY_VECTOR_DIM/EMBED_DIM
     - MEMORY_ENSURE_ON_START=0  -> ensure lazily on first tool call
     """
+    client = _get_qdrant_client()
     try:
         client.get_collection(name)
         return True
     except Exception:
         pass
+    finally:
+        _return_qdrant_client(client)
 
     # Choose dense dimension based on config: probe (default) vs env-configured
     if MEMORY_PROBE_EMBED_DIM:
@@ -319,14 +348,19 @@ def _ensure_collection(name: str):
     except Exception:
         pass
 
-    client.create_collection(
-        collection_name=name,
-        vectors_config=vectors_cfg,
-        hnsw_config=models.HnswConfigDiff(m=16, ef_construct=256),
-    )
-    vector_names = list(vectors_cfg.keys())
-    print(f"[MEMORY_SERVER] Created collection '{name}' with vectors: {vector_names}")
-    return True
+    # Get a fresh client for collection creation
+    client = _get_qdrant_client()
+    try:
+        client.create_collection(
+            collection_name=name,
+            vectors_config=vectors_cfg,
+            hnsw_config=models.HnswConfigDiff(m=16, ef_construct=256),
+        )
+        vector_names = list(vectors_cfg.keys())
+        print(f"[MEMORY_SERVER] Created collection '{name}' with vectors: {vector_names}")
+        return True
+    finally:
+        _return_qdrant_client(client)
 
 
 # Optional eager collection ensure on startup (enabled by default for backward compatibility).
@@ -463,7 +497,14 @@ def memory_store(
     )
     # wait=True blocks until Qdrant confirms write; set MEMORY_UPSERT_WAIT=0 for async writes
     _upsert_wait = os.environ.get("MEMORY_UPSERT_WAIT", "1").strip().lower() in {"1", "true", "yes", "on"}
-    client.upsert(collection_name=coll, points=[point], wait=_upsert_wait)
+
+    # Use pooled client for upsert
+    client = _get_qdrant_client()
+    try:
+        client.upsert(collection_name=coll, points=[point], wait=_upsert_wait)
+    finally:
+        _return_qdrant_client(client)
+
     return {
         "ok": True,
         "id": pid,
@@ -536,46 +577,51 @@ def memory_find(
     flt = models.Filter(must=must) if must else None
 
     # Two searches (prefer query_points) then simple RRF-like merge
-    if use_dense:
-        try:
-            qp_dense = client.query_points(
-                collection_name=coll,
-                query=dense,
-                using=VECTOR_NAME,
-                query_filter=flt,
-                limit=max(10, lim),
-                with_payload=True,
-            )
-            res_dense = getattr(qp_dense, "points", qp_dense)
-        except AttributeError:
-            res_dense = client.search(
-                collection_name=coll,
-                query_vector=(VECTOR_NAME, dense),
-                query_filter=flt,
-                limit=max(10, lim),
-                with_payload=True,
-            )
-    else:
-        res_dense = []
-
+    # Use pooled client for all search operations
+    client = _get_qdrant_client()
     try:
-        qp_lex = client.query_points(
-            collection_name=coll,
-            query=lex,
-            using=LEX_VECTOR_NAME,
-            query_filter=flt,
-            limit=max(10, lim),
-            with_payload=True,
-        )
-        res_lex = getattr(qp_lex, "points", qp_lex)
-    except AttributeError:
-        res_lex = client.search(
-            collection_name=coll,
-            query_vector=(LEX_VECTOR_NAME, lex),
-            query_filter=flt,
-            limit=max(10, lim),
-            with_payload=True,
-        )
+        if use_dense:
+            try:
+                qp_dense = client.query_points(
+                    collection_name=coll,
+                    query=dense,
+                    using=VECTOR_NAME,
+                    query_filter=flt,
+                    limit=max(10, lim),
+                    with_payload=True,
+                )
+                res_dense = getattr(qp_dense, "points", qp_dense)
+            except AttributeError:
+                res_dense = client.search(
+                    collection_name=coll,
+                    query_vector=(VECTOR_NAME, dense),
+                    query_filter=flt,
+                    limit=max(10, lim),
+                    with_payload=True,
+                )
+        else:
+            res_dense = []
+
+        try:
+            qp_lex = client.query_points(
+                collection_name=coll,
+                query=lex,
+                using=LEX_VECTOR_NAME,
+                query_filter=flt,
+                limit=max(10, lim),
+                with_payload=True,
+            )
+            res_lex = getattr(qp_lex, "points", qp_lex)
+        except AttributeError:
+            res_lex = client.search(
+                collection_name=coll,
+                query_vector=(LEX_VECTOR_NAME, lex),
+                query_filter=flt,
+                limit=max(10, lim),
+                with_payload=True,
+            )
+    finally:
+        _return_qdrant_client(client)
 
     def is_memory_like(payload: Dict[str, Any]) -> bool:
         md = (payload or {}).get("metadata") or {}

--- a/scripts/mcp_memory_server.py
+++ b/scripts/mcp_memory_server.py
@@ -45,7 +45,6 @@ try:
     from scripts.qdrant_client_manager import (
         get_qdrant_client,
         return_qdrant_client,
-        pooled_qdrant_client,
     )
     _POOL_AVAILABLE = True
 except ImportError:

--- a/scripts/mcp_memory_server.py
+++ b/scripts/mcp_memory_server.py
@@ -88,14 +88,15 @@ except Exception:
 # Use the centralized embedder from scripts.embedder for consistent caching.
 # This eliminates duplicate model loading and ensures consistent behavior.
 
-# Reference to the centralized cache for cold-skip detection
+# Reference to the centralized embedder for cold-skip detection
 try:
     from scripts.embedder import get_embedding_model as _centralized_get_embedding_model
-    from scripts.embedder import _EMBED_MODEL_CACHE
+    from scripts.embedder import is_model_cached as _is_model_cached
     _EMBEDDER_AVAILABLE = True
 except ImportError:
     _EMBEDDER_AVAILABLE = False
-    _EMBED_MODEL_CACHE: Dict[str, Any] = {}  # Fallback empty cache
+    def _is_model_cached(model_name: str = "") -> bool:  # type: ignore[misc]
+        return False  # Fallback: assume not cached
 
 def _get_embedding_model():
     """Get the embedding model using the centralized embedder.
@@ -543,7 +544,7 @@ def memory_find(
     _ensure_once(coll)
 
     use_dense = True
-    if MEMORY_COLD_SKIP_DENSE and EMBEDDING_MODEL not in _EMBED_MODEL_CACHE:
+    if MEMORY_COLD_SKIP_DENSE and not _is_model_cached(EMBEDDING_MODEL):
         use_dense = False
     if use_dense:
         model = _get_embedding_model()

--- a/scripts/qdrant_client_manager.py
+++ b/scripts/qdrant_client_manager.py
@@ -16,7 +16,7 @@ from qdrant_client import QdrantClient
 # Connection pool implementation
 class QdrantConnectionPool:
     """Thread-safe connection pool for QdrantClient instances."""
-    
+
     def __init__(self, max_size: int = 10, max_lifetime: float = 300.0):
         self.max_size = max_size
         self.max_lifetime = max_lifetime  # seconds
@@ -25,23 +25,26 @@ class QdrantConnectionPool:
         self._created_count = 0
         self._hits = 0
         self._misses = 0
-    
+        # Track temporary (overflow) clients for cleanup on shutdown
+        self._overflow_clients: weakref.WeakSet = weakref.WeakSet()
+        self._overflow_refs: List[QdrantClient] = []  # Strong refs to prevent premature GC
+
     def get_client(self, url: str, api_key: Optional[str] = None) -> QdrantClient:
         """Get a client from pool or create a new one."""
         with self._pool_lock:
             # Clean up expired connections
             self._cleanup_expired()
-            
+
             # Try to find a matching client in pool
             for i, conn in enumerate(self._pool):
-                if (conn['url'] == url and 
-                    conn['api_key'] == api_key and 
+                if (conn['url'] == url and
+                    conn['api_key'] == api_key and
                     conn['in_use'] == False):
                     conn['in_use'] = True
                     conn['last_used'] = time.time()
                     self._hits += 1
                     return conn['client']
-            
+
             # No suitable client found, create a new one
             if self._created_count < self.max_size:
                 client = QdrantClient(url=url, api_key=api_key)
@@ -58,9 +61,12 @@ class QdrantConnectionPool:
                 self._misses += 1
                 return client
             else:
-                # Pool is full, create a temporary client (not pooled)
+                # Pool is full, create a temporary client (tracked for shutdown cleanup)
                 self._misses += 1
-                return QdrantClient(url=url, api_key=api_key)
+                client = QdrantClient(url=url, api_key=api_key)
+                self._overflow_clients.add(client)
+                self._overflow_refs.append(client)
+                return client
     
     def return_client(self, client: QdrantClient):
         """Return a client to the pool."""
@@ -91,8 +97,9 @@ class QdrantConnectionPool:
             self._created_count -= 1
     
     def close_all(self):
-        """Close all connections in the pool."""
+        """Close all connections in the pool and overflow clients."""
         with self._pool_lock:
+            # Close pooled connections
             for conn in self._pool:
                 try:
                     conn['client'].close()
@@ -100,7 +107,16 @@ class QdrantConnectionPool:
                     pass
             self._pool.clear()
             self._created_count = 0
-    
+
+            # Close overflow (temporary) clients
+            for client in self._overflow_refs:
+                try:
+                    client.close()
+                except Exception:
+                    pass
+            self._overflow_refs.clear()
+            # WeakSet will be empty once refs are cleared
+
     def get_stats(self) -> Dict[str, int]:
         """Get pool statistics."""
         with self._pool_lock:
@@ -109,7 +125,8 @@ class QdrantConnectionPool:
                 'created_count': self._created_count,
                 'hits': self._hits,
                 'misses': self._misses,
-                'in_use': sum(1 for conn in self._pool if conn['in_use'])
+                'in_use': sum(1 for conn in self._pool if conn['in_use']),
+                'overflow_clients': len(self._overflow_refs)
             }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import time
+import urllib.request
 from pathlib import Path
 
 import pytest
@@ -39,3 +41,164 @@ def _disable_tokenizers_parallelism():
             os.environ.pop("TOKENIZERS_PARALLELISM", None)
         else:
             os.environ["TOKENIZERS_PARALLELISM"] = prev
+
+
+def _wait_for_qdrant(url: str, timeout: int = 60) -> bool:
+    """Wait for Qdrant to be ready at the given URL."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url + "/readyz", timeout=2) as r:
+                if 200 <= r.status < 300:
+                    return True
+        except Exception:
+            pass
+        time.sleep(1)
+    return False
+
+
+@pytest.fixture(scope="module")
+def qdrant_url():
+    """Provide Qdrant URL - uses CI service container or testcontainers (local).
+
+    In CI (GitHub Actions), uses the pre-configured Qdrant service at localhost:6333.
+    Locally, this fixture ALWAYS spins up a testcontainers Qdrant instance to avoid
+    accidentally polluting a developer's local Qdrant with test collections.
+    """
+    # Only use pre-configured Qdrant in CI environment (GitHub Actions sets CI=true)
+    is_ci = os.environ.get("CI", "").lower() in ("true", "1", "yes")
+    if is_ci:
+        # Hardcoded CI Qdrant URL - the GitHub Actions service container
+        ci_url = "http://localhost:6333"
+        if _wait_for_qdrant(ci_url, timeout=30):
+            yield ci_url
+            return
+        # If not reachable in CI, fail explicitly
+        pytest.fail(f"CI Qdrant service not reachable at {ci_url}")
+
+    # Local development: ALWAYS use testcontainers (safe isolation)
+    os.environ.setdefault("TESTCONTAINERS_RYUK_DISABLED", "true")
+    os.environ.setdefault("TESTCONTAINERS_RYUK_TIMEOUT", "0")
+
+    try:
+        from testcontainers.core.container import DockerContainer
+    except ImportError:
+        pytest.skip("testcontainers not available and QDRANT_URL not set")
+
+    container = (
+        DockerContainer("qdrant/qdrant:latest")
+        .with_env("TESTCONTAINERS_RYUK_DISABLED", "true")
+        .with_env("TESTCONTAINERS_RYUK_TIMEOUT", "0")
+        .with_exposed_ports(6333)
+    )
+
+    try:
+        container.start()
+        host = container.get_container_host_ip()
+
+        # Wait for port mapping
+        deadline = time.time() + 30
+        port = None
+        last_exc = None
+        while time.time() < deadline:
+            try:
+                port = int(container.get_exposed_port(6333))
+                break
+            except Exception as exc:
+                last_exc = exc
+                time.sleep(0.25)
+
+        if port is None:
+            raise RuntimeError(f"qdrant port mapping unavailable: {last_exc}")
+
+        url = f"http://{host}:{port}"
+
+        if not _wait_for_qdrant(url, timeout=60):
+            pytest.skip("Qdrant not ready in time")
+
+        yield url
+    finally:
+        try:
+            container.stop()
+        except Exception:
+            pass
+
+
+# Alias for backward compatibility with existing tests
+@pytest.fixture(scope="module")
+def qdrant_container(qdrant_url):
+    """Backward-compatible alias for qdrant_url fixture."""
+    return qdrant_url
+
+
+# Track collections created during tests for cleanup
+_test_collections: list[tuple[str, str]] = []  # (qdrant_url, collection_name)
+
+
+@pytest.fixture
+def test_collection(qdrant_url):
+    """Create a unique test collection name and register it for cleanup.
+
+    Usage:
+        def test_something(qdrant_url, test_collection):
+            # test_collection is a unique name like "test-a1b2c3d4"
+            # It will be automatically deleted after the test
+    """
+    import uuid
+    collection_name = f"test-{uuid.uuid4().hex[:8]}"
+    _test_collections.append((qdrant_url, collection_name))
+    yield collection_name
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _cleanup_test_collections(qdrant_url):
+    """Automatically clean up all test collections after each test module."""
+    yield
+
+    # Cleanup after module completes
+    if not _test_collections:
+        return
+
+    try:
+        from qdrant_client import QdrantClient
+        client = QdrantClient(url=qdrant_url, timeout=10)
+
+        # Get list of collections to delete (ones that match our URL)
+        to_delete = [name for url, name in _test_collections if url == qdrant_url]
+
+        for collection_name in to_delete:
+            try:
+                client.delete_collection(collection_name)
+            except Exception:
+                pass  # Collection might not exist or already deleted
+
+        # Remove cleaned up entries
+        _test_collections[:] = [(u, n) for u, n in _test_collections if u != qdrant_url]
+    except Exception:
+        pass  # Best effort cleanup
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _final_cleanup_all_test_collections():
+    """Final cleanup at end of test session - delete any remaining test-* collections."""
+    yield
+
+    # Only run cleanup in CI to avoid touching local Qdrant
+    is_ci = os.environ.get("CI", "").lower() in ("true", "1", "yes")
+    if not is_ci:
+        return
+
+    try:
+        from qdrant_client import QdrantClient
+        client = QdrantClient(url="http://localhost:6333", timeout=10)
+
+        # List all collections and delete ones starting with "test-"
+        collections = client.get_collections().collections
+        for col in collections:
+            if col.name.startswith("test-"):
+                try:
+                    client.delete_collection(col.name)
+                except Exception:
+                    pass
+    except Exception:
+        pass  # Best effort cleanup

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,7 +131,9 @@ def qdrant_container(qdrant_url):
     return qdrant_url
 
 
-# Track collections created during tests for cleanup
+# Track collections created during tests for cleanup (thread-safe for pytest-xdist)
+import threading
+_test_collections_lock = threading.Lock()
 _test_collections: list[tuple[str, str]] = []  # (qdrant_url, collection_name)
 
 
@@ -143,32 +145,52 @@ def test_collection(qdrant_url):
         def test_something(qdrant_url, test_collection):
             # test_collection is a unique name like "test-a1b2c3d4"
             # It will be automatically deleted after the test
+
+    Thread-safe: uses lock for pytest-xdist compatibility.
     """
     import uuid
     collection_name = f"test-{uuid.uuid4().hex[:8]}"
-    _test_collections.append((qdrant_url, collection_name))
+    with _test_collections_lock:
+        _test_collections.append((qdrant_url, collection_name))
     yield collection_name
+
+    # Clean up THIS test's collection immediately after the test
+    # This ensures each test cleans up its own collection, avoiding cross-test races
+    try:
+        from qdrant_client import QdrantClient
+        client = QdrantClient(url=qdrant_url, timeout=10)
+        client.delete_collection(collection_name)
+    except Exception:
+        pass  # Collection might not exist or already deleted
+
+    # Remove from tracking list
+    with _test_collections_lock:
+        _test_collections[:] = [(u, n) for u, n in _test_collections
+                                 if not (u == qdrant_url and n == collection_name)]
 
 
 @pytest.fixture(scope="function", autouse=True)
 def _cleanup_test_collections(qdrant_url):
-    """Clean up test collections after each test function that uses test_collection.
+    """Clean up any orphaned test collections after each test function.
 
-    This fixture has function scope to match the test_collection fixture, ensuring
-    collections are cleaned up immediately after each test rather than accumulating.
+    This is a safety net for collections that weren't cleaned up by test_collection fixture.
+    Thread-safe: uses lock for pytest-xdist compatibility.
     """
     yield
 
-    # Only cleanup if this test used test_collection fixture
-    if not _test_collections:
+    # Only cleanup if there are orphaned collections
+    with _test_collections_lock:
+        if not _test_collections:
+            return
+        # Get list of collections to delete (ones that match our URL)
+        to_delete = [name for url, name in _test_collections if url == qdrant_url]
+
+    if not to_delete:
         return
 
     try:
         from qdrant_client import QdrantClient
         client = QdrantClient(url=qdrant_url, timeout=10)
-
-        # Get list of collections to delete (ones that match our URL)
-        to_delete = [name for url, name in _test_collections if url == qdrant_url]
 
         for collection_name in to_delete:
             try:
@@ -177,7 +199,8 @@ def _cleanup_test_collections(qdrant_url):
                 pass  # Collection might not exist or already deleted
 
         # Remove cleaned up entries
-        _test_collections[:] = [(u, n) for u, n in _test_collections if u != qdrant_url]
+        with _test_collections_lock:
+            _test_collections[:] = [(u, n) for u, n in _test_collections if u != qdrant_url]
     except Exception:
         pass  # Best effort cleanup
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ def _wait_for_qdrant(url: str, timeout: int = 60) -> bool:
                 if 200 <= r.status < 300:
                     return True
         except Exception:
-            pass
+            pass  # Qdrant may not be ready yet; ignore transient errors and retry until timeout.
         time.sleep(1)
     return False
 
@@ -121,7 +121,7 @@ def qdrant_url():
         try:
             container.stop()
         except Exception:
-            pass
+            pass  # Best-effort cleanup: ignore container shutdown errors in tests
 
 
 # Alias for backward compatibility with existing tests
@@ -150,12 +150,16 @@ def test_collection(qdrant_url):
     yield collection_name
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="function", autouse=True)
 def _cleanup_test_collections(qdrant_url):
-    """Automatically clean up all test collections after each test module."""
+    """Clean up test collections after each test function that uses test_collection.
+
+    This fixture has function scope to match the test_collection fixture, ensuring
+    collections are cleaned up immediately after each test rather than accumulating.
+    """
     yield
 
-    # Cleanup after module completes
+    # Only cleanup if this test used test_collection fixture
     if not _test_collections:
         return
 
@@ -199,6 +203,6 @@ def _final_cleanup_all_test_collections():
                 try:
                     client.delete_collection(col.name)
                 except Exception:
-                    pass
+                    pass  # Best effort per-collection cleanup; ignore if delete fails
     except Exception:
         pass  # Best effort cleanup

--- a/tests/test_collection_memory_backup_restore.py
+++ b/tests/test_collection_memory_backup_restore.py
@@ -7,8 +7,7 @@ from types import SimpleNamespace
 import pytest
 from qdrant_client import QdrantClient, models
 
-# Reuse the existing Qdrant testcontainer fixture
-from tests.test_integration_qdrant import qdrant_container  # noqa: F401
+# qdrant_container fixture is provided by conftest.py (no import needed)
 
 
 ing = importlib.import_module("scripts.ingest_code")

--- a/tests/test_globs_and_snippet.py
+++ b/tests/test_globs_and_snippet.py
@@ -62,8 +62,8 @@ def test_run_hybrid_search_list_globs(monkeypatch):
         _Pt("2", "tests/b_test.py"),
         _Pt("3", "docs/readme.md"),
     ]
-    # Patch the symbol used inside hybrid_search
-    monkeypatch.setattr(hyb, "QdrantClient", lambda *a, **k: FakeQdrant(pts))
+    # Patch client factory used inside hybrid_search so we don't hit real Qdrant
+    monkeypatch.setattr(hyb, "get_qdrant_client", lambda *a, **k: FakeQdrant(pts))
     monkeypatch.setenv("EMBEDDING_MODEL", "unit-test")
     monkeypatch.setenv("QDRANT_URL", "http://localhost:6333")
 
@@ -94,7 +94,7 @@ def test_run_hybrid_search_slugged_path_globs(monkeypatch):
         _Pt("1", "/work/repo-slug/src/a.py"),
         _Pt("2", "/work/other/docs/readme.md"),
     ]
-    monkeypatch.setattr(hyb, "QdrantClient", lambda *a, **k: FakeQdrant(pts))
+    monkeypatch.setattr(hyb, "get_qdrant_client", lambda *a, **k: FakeQdrant(pts))
     monkeypatch.setenv("EMBEDDING_MODEL", "unit-test")
     monkeypatch.setenv("QDRANT_URL", "http://localhost:6333")
     monkeypatch.setattr(hyb, "TextEmbedding", lambda *a, **k: FakeEmbed())

--- a/tests/test_hybrid_cache_bm25.py
+++ b/tests/test_hybrid_cache_bm25.py
@@ -69,8 +69,8 @@ def test_results_cache_hit_is_deterministic_and_avoids_second_backend_call(monke
     ]
     backend = _CountingQdrant(pts)
 
-    # Monkeypatch backends and model
-    monkeypatch.setattr(hyb, "QdrantClient", lambda *a, **k: backend)
+    # Monkeypatch backends and model (patch client factory used in hybrid_search)
+    monkeypatch.setattr(hyb, "get_qdrant_client", lambda *a, **k: backend)
     monkeypatch.setattr(hyb, "TextEmbedding", lambda *a, **k: _FakeEmbed())
     monkeypatch.setattr(hyb, "_get_embedding_model", lambda *a, **k: _FakeEmbed())
     monkeypatch.setenv("EMBEDDING_MODEL", "unit-test")

--- a/tests/test_hybrid_relations.py
+++ b/tests/test_hybrid_relations.py
@@ -61,7 +61,8 @@ def test_run_hybrid_search_relations_and_related_paths(monkeypatch):
     # Add an import-like path so a.py imports b -> should appear via import-based resolution
     pts[0].payload["metadata"]["imports"] = ["./b"]
 
-    monkeypatch.setattr(hyb, "QdrantClient", lambda *a, **k: FakeQdrant(pts))
+    # Patch client factory used inside hybrid_search so we don't hit real Qdrant
+    monkeypatch.setattr(hyb, "get_qdrant_client", lambda *a, **k: FakeQdrant(pts))
     monkeypatch.setattr(hyb, "TextEmbedding", lambda *a, **k: FakeEmbed())
     monkeypatch.setattr(hyb, "_get_embedding_model", lambda *a, **k: FakeEmbed())
     monkeypatch.setenv("EMBEDDING_MODEL", "unit-test")

--- a/tests/test_integration_qdrant.py
+++ b/tests/test_integration_qdrant.py
@@ -34,57 +34,8 @@ class FakeEmbedder:
             yield self._Vec(vec)
 
 
-@pytest.fixture(scope="module")
-def qdrant_container():
-    os.environ.setdefault("TESTCONTAINERS_RYUK_DISABLED", "true")
-    os.environ.setdefault("TESTCONTAINERS_RYUK_TIMEOUT", "0")
-    try:
-        from testcontainers.core.container import DockerContainer
-    except Exception as e:  # pragma: no cover
-        pytest.skip("testcontainers not available")
-    import time, urllib.request
-
-    container = DockerContainer("qdrant/qdrant:latest").with_env(
-        "TESTCONTAINERS_RYUK_DISABLED", "true"
-    ).with_env("TESTCONTAINERS_RYUK_TIMEOUT", "0").with_exposed_ports(6333)
-
-    ready = False
-    try:
-        container.start()
-        host = container.get_container_host_ip()
-        deadline = time.time() + 30
-        port = None
-        last_exc = None
-        while time.time() < deadline:
-            try:
-                port = int(container.get_exposed_port(6333))
-                break
-            except Exception as exc:
-                last_exc = exc
-                time.sleep(0.25)
-        if port is None:
-            raise RuntimeError(f"qdrant port mapping unavailable: {last_exc}")
-        url = f"http://{host}:{port}"
-
-        deadline = time.time() + 60
-        while time.time() < deadline:
-            try:
-                with urllib.request.urlopen(url + "/readyz", timeout=2) as r:
-                    if 200 <= r.status < 300:
-                        ready = True
-                        break
-            except Exception:
-                pass
-            time.sleep(1)
-        if not ready:
-            pytest.skip("Qdrant not ready in time")
-
-        yield url
-    finally:
-        try:
-            container.stop()
-        except Exception:
-            pass
+# qdrant_container fixture is now provided by conftest.py
+# It uses QDRANT_URL env var (CI) or testcontainers (local dev)
 
 
 @pytest.mark.integration

--- a/tests/test_subprocess_hybrid_smoke.py
+++ b/tests/test_subprocess_hybrid_smoke.py
@@ -11,59 +11,8 @@ pytestmark = pytest.mark.integration
 # Always enabled; smoke runs as part of full suite
 
 
-@pytest.fixture(scope="module")
-def qdrant_container():
-    try:
-        from testcontainers.core.container import DockerContainer
-    except Exception:
-        pytest.skip("testcontainers not available")
-    import time, urllib.request
-
-    # Disable ryuk to avoid port mapping flakiness in some environments
-    os.environ.setdefault("TESTCONTAINERS_RYUK_DISABLED", "true")
-    os.environ.setdefault("TESTCONTAINERS_RYUK_TIMEOUT", "0")
-    container = (
-        DockerContainer("qdrant/qdrant:latest")
-        .with_env("TESTCONTAINERS_RYUK_DISABLED", "true")
-        .with_env("TESTCONTAINERS_RYUK_TIMEOUT", "0")
-        .with_exposed_ports(6333)
-    )
-    ready = False
-    try:
-        container.start()
-        host = container.get_container_host_ip()
-        deadline = time.time() + 30
-        last_exc: Exception | None = None
-        port = None
-        while time.time() < deadline:
-            try:
-                port = int(container.get_exposed_port(6333))
-                break
-            except Exception as exc:  # pragma: no cover - retry only in flaky envs
-                last_exc = exc
-                time.sleep(0.25)
-        else:
-            raise RuntimeError(f"qdrant port mapping unavailable: {last_exc}")
-        url = f"http://{host}:{port}"
-        # Poll readiness endpoint up to 60s
-        deadline = time.time() + 60
-        while time.time() < deadline:
-            try:
-                with urllib.request.urlopen(url + "/readyz", timeout=2) as r:
-                    if 200 <= r.status < 300:
-                        ready = True
-                        break
-            except Exception:
-                pass
-            time.sleep(1)
-        if not ready:
-            raise RuntimeError("qdrant container failed readiness check within timeout")
-        yield url
-    finally:
-        try:
-            container.stop()
-        except Exception:
-            pass
+# qdrant_container fixture is now provided by conftest.py
+# It uses QDRANT_URL env var (CI) or testcontainers (local dev)
 
 
 @pytest.mark.integration

--- a/tests/test_tier2_fallback.py
+++ b/tests/test_tier2_fallback.py
@@ -37,21 +37,21 @@ class FakeEmbedder:
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_tier2_fallback_unconditional_with_language_filter(tmp_path, monkeypatch, qdrant_container):
-    # Env for services
-    os.environ["QDRANT_URL"] = qdrant_container
-    os.environ["COLLECTION_NAME"] = f"test-{uuid.uuid4().hex[:8]}"
-    os.environ["USE_TREE_SITTER"] = "0"
-    os.environ["HYBRID_IN_PROCESS"] = "1"
-    os.environ["EMBEDDING_MODEL"] = "fake"
-    # Enable REFRAG_MODE to test with mini vectors; disable gating so Tier-1
-    # uses standard search (we control filtering via path_glob).
-    # Tier-2 fallback triggers when Tier-1 returns zero results.
-    os.environ["REFRAG_MODE"] = "1"
-    os.environ["REFRAG_GATE_FIRST"] = "0"
-    os.environ["PATTERN_VECTORS"] = "0"
+@pytest.mark.parametrize("refrag_mode", ["0", "1"], ids=["refrag_off", "refrag_on"])
+async def test_tier2_fallback_unconditional_with_language_filter(tmp_path, monkeypatch, qdrant_container, refrag_mode):
+    # Use monkeypatch to ensure proper test isolation for env vars
+    monkeypatch.setenv("QDRANT_URL", qdrant_container)
+    monkeypatch.setenv("COLLECTION_NAME", f"test-{uuid.uuid4().hex[:8]}")
+    monkeypatch.setenv("USE_TREE_SITTER", "0")
+    monkeypatch.setenv("HYBRID_IN_PROCESS", "1")
+    monkeypatch.setenv("EMBEDDING_MODEL", "fake")
+    # Test Tier-2 fallback with both REFRAG_MODE on and off.
+    # Tier-2 triggers when Tier-1 returns zero results (due to path_glob).
+    monkeypatch.setenv("REFRAG_MODE", refrag_mode)
+    monkeypatch.setenv("REFRAG_GATE_FIRST", "0")
+    monkeypatch.setenv("PATTERN_VECTORS", "0")
     # Disable multi-collection fallback to avoid creating extra collections
-    os.environ["CTX_MULTI_COLLECTION"] = "0"
+    monkeypatch.setenv("CTX_MULTI_COLLECTION", "0")
 
     # Stub embeddings everywhere (FakeEmbedder produces 32-dim vectors)
     monkeypatch.setattr(ing, "TextEmbedding", lambda *a, **k: FakeEmbedder("fake"))

--- a/tests/test_tier2_fallback.py
+++ b/tests/test_tier2_fallback.py
@@ -44,7 +44,14 @@ async def test_tier2_fallback_unconditional_with_language_filter(tmp_path, monke
     os.environ["USE_TREE_SITTER"] = "0"
     os.environ["HYBRID_IN_PROCESS"] = "1"
     os.environ["EMBEDDING_MODEL"] = "fake"
-    os.environ["REFRAG_GATE_FIRST"] = "1"  # ensure Tier-1 gate-first path is active
+    # Enable REFRAG_MODE to test with mini vectors; disable gating so Tier-1
+    # uses standard search (we control filtering via path_glob).
+    # Tier-2 fallback triggers when Tier-1 returns zero results.
+    os.environ["REFRAG_MODE"] = "1"
+    os.environ["REFRAG_GATE_FIRST"] = "0"
+    os.environ["PATTERN_VECTORS"] = "0"
+    # Disable multi-collection fallback to avoid creating extra collections
+    os.environ["CTX_MULTI_COLLECTION"] = "0"
 
     # Stub embeddings everywhere (FakeEmbedder produces 32-dim vectors)
     monkeypatch.setattr(ing, "TextEmbedding", lambda *a, **k: FakeEmbedder("fake"))
@@ -53,6 +60,10 @@ async def test_tier2_fallback_unconditional_with_language_filter(tmp_path, monke
     monkeypatch.setattr(srv, "_get_embedding_model", lambda *a, **k: FakeEmbedder("fake"))
     monkeypatch.setattr(hy, "TextEmbedding", lambda *a, **k: FakeEmbedder("fake"))
     monkeypatch.setattr(hy, "_get_embedding_model", lambda *a, **k: FakeEmbedder("fake"))
+
+    # Clear collection cache to ensure fresh schema checks
+    from scripts.ingest.qdrant import ENSURED_COLLECTIONS
+    ENSURED_COLLECTIONS.clear()
 
     # Create tiny repo
     (tmp_path / "pkg").mkdir()

--- a/tests/test_tier2_fallback.py
+++ b/tests/test_tier2_fallback.py
@@ -31,53 +31,8 @@ class FakeEmbedder:
             yield self._Vec(vec)
 
 
-@pytest.fixture(scope="module")
-def qdrant_container():
-    os.environ.setdefault("TESTCONTAINERS_RYUK_DISABLED", "true")
-    os.environ.setdefault("TESTCONTAINERS_RYUK_TIMEOUT", "0")
-    try:
-        from testcontainers.core.container import DockerContainer
-    except Exception:  # pragma: no cover
-        pytest.skip("testcontainers not available")
-    import time, urllib.request
-
-    container = DockerContainer("qdrant/qdrant:latest")
-    try:
-        container.with_env("TESTCONTAINERS_RYUK_DISABLED", "true")
-        container.with_env("TESTCONTAINERS_RYUK_TIMEOUT", "0")
-        container.with_exposed_ports(6333)
-        container.start()
-        host = container.get_container_host_ip()
-        deadline = time.time() + 30
-        port = None
-        last_exc = None
-        while time.time() < deadline:
-            try:
-                port = int(container.get_exposed_port(6333))
-                break
-            except Exception as exc:
-                last_exc = exc
-                time.sleep(0.25)
-        if port is None:
-            raise RuntimeError(f"qdrant port mapping unavailable: {last_exc}")
-        url = f"http://{host}:{port}"
-
-        deadline = time.time() + 60
-        while time.time() < deadline:
-            try:
-                with urllib.request.urlopen(url + "/readyz", timeout=2) as r:
-                    if 200 <= r.status < 300:
-                        break
-            except Exception:
-                pass
-            time.sleep(1)
-
-        yield url
-    finally:
-        try:
-            container.stop()
-        except Exception:
-            pass
+# qdrant_container fixture is now provided by conftest.py
+# It uses QDRANT_URL env var (CI) or testcontainers (local dev)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Refactored deduplication cleanup to ensure thread safety by holding the lock during iteration and deletion. Updated hybrid_search to use a pooled Qdrant client and introduced a file content cache for snippet extraction, reducing redundant disk reads. Changed default DEBUG_CONTEXT_ANSWER to '0' in mcp_indexer_server for production safety. Made memory_store upsert wait behavior configurable via MEMORY_UPSERT_WAIT environment variable.