### PR TITLE
Update ClickHouse config and OpenLit initialization

### DIFF
--- a/config/clickhouse-config.xml
+++ b/config/clickhouse-config.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 <clickhouse>
+    <!-- Listen on IPv4 only (IPv6 may be disabled on host) -->
+    <listen_host>0.0.0.0</listen_host>
+
     <logger>
         <level>warning</level>
         <console>true</console>

--- a/config/docker_related_config.xml
+++ b/config/docker_related_config.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <!-- Listen on IPv4 only - IPv6 disabled on host -->
+    <listen_host>0.0.0.0</listen_host>
+    <listen_try>1</listen_try>
+</clickhouse>
+

--- a/docker-compose.openlit.yml
+++ b/docker-compose.openlit.yml
@@ -15,6 +15,7 @@ services:
     volumes:
       - clickhouse_data:/var/lib/clickhouse
       - ./config/clickhouse-config.xml:/etc/clickhouse-server/config.d/custom-config.xml:ro
+      - ./config/docker_related_config.xml:/etc/clickhouse-server/config.d/docker_related_config.xml:ro
     environment:
       - CLICKHOUSE_PASSWORD=OPENLIT
       - CLICKHOUSE_USER=default

--- a/scripts/openlit_init.py
+++ b/scripts/openlit_init.py
@@ -33,10 +33,10 @@ def init_openlit():
         # Initialize OpenLit with modern params
         openlit.init(
             otlp_endpoint=_otel_endpoint,
-            service_name=_app_name,
+            application_name=_app_name,
             environment=_environment,
             disabled_instrumentors=None,
-            capture_message_content=True,
+            trace_content=True,
         )
         
         print(f"[OpenLit] Initialized with endpoint={_otel_endpoint}, service={_app_name}")


### PR DESCRIPTION
Added docker-specific ClickHouse config to listen on IPv4 only and updated docker-compose to mount the new config. Modified openlit_init.py to use 'application_name' and 'trace_content' parameters for OpenLit initialization.