### PR TITLE
Fix favicon 404 error by removing PNG favicon reference

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8" />
         <link rel="icon" href="%sveltekit.assets%/favicon.svg" type="image/svg+xml" />
-        <link rel="icon" href="%sveltekit.assets%/favicon.png" type="image/png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Context Engine - MCP Retrieval Stack</title>
 		<meta name="description" content="MCP retrieval stack for AI coding assistants. Hybrid code search, ReFRAG micro-chunking, local LLM enhancement." />


### PR DESCRIPTION
- Remove favicon.png link from app.html
- Keep only SVG favicon which is already present
- Resolves build failure in GitHub Actions deployment