### PR TITLE
fix: improve metrics icon contrast with white color

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -766,7 +766,7 @@
 	}
 
 	.metric-icon {
-		color: #8b5cf6;
+		color: rgba(255, 255, 255, 0.9);
 		background: rgba(139, 92, 246, 0.2);
 		padding: var(--spacing-sm);
 		border-radius: var(--radius-sm);


### PR DESCRIPTION
Change metric icons from purple to white for better readability against purple background in glassmorphism theme