### PR TITLE
fix: remove horizontal scrolling from desktop tables

### DIFF
--- a/src/routes/docs/[slug]/+page.svelte
+++ b/src/routes/docs/[slug]/+page.svelte
@@ -218,16 +218,17 @@
 			border-radius: var(--radius-sm);
 			overflow: hidden;
 			border: 1px solid rgba(255, 255, 255, 0.15);
-			// Mobile responsiveness for tables
-			display: block;
-			overflow-x: auto;
-			white-space: nowrap;
 		}
 
 		// Mobile table optimizations
 		@media (max-width: 768px) {
 			:global(table) {
 				font-size: 0.85rem;
+				// Enable horizontal scrolling only on tablets and smaller
+				display: block;
+				overflow-x: auto;
+				white-space: nowrap;
+				-webkit-overflow-scrolling: touch;
 			}
 		}
 


### PR DESCRIPTION
- Remove block display and overflow-x from desktop table styling
- Keep horizontal scrolling only for tablets and smaller (≤768px)
- Preserve mobile card layout for phones (≤480px)
- Maintain normal table behavior on desktop screens

Tables now display properly on desktop without unnecessary scroll bars while retaining mobile-friendly responsive behavior.