### PR TITLE
feat: widen documentation layout for better screen utilization

### DIFF
--- a/src/routes/docs/[slug]/+page.svelte
+++ b/src/routes/docs/[slug]/+page.svelte
@@ -51,7 +51,7 @@
 	}
 
 	.container {
-		max-width: 900px;
+		max-width: 1200px;
 		margin: 0 auto;
 		padding: 0 var(--spacing-md);
 	}
@@ -94,7 +94,7 @@
 		color: rgba(255, 255, 255, 0.85);
 		font-size: 1.1rem;
 		margin-bottom: var(--spacing-lg);
-		max-width: 600px;
+		max-width: 800px;
 		margin-left: auto;
 		margin-right: auto;
 		text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
- Increase container max-width from 900px to 1200px (33% wider)
- Expand description max-width from 600px to 800px
- Improve readability and reduce cramped appearance
- Better accommodate wide configuration tables
- Maintain mobile responsiveness on smaller screens

Makes better use of modern screen sizes while preserving the glassmorphism design and responsive behavior.