### PR TITLE
feat: update hero icon from BotOff to Sparkles

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,7 @@
 		Layers,
 		Brain,
 		Plug,
-		BotOff,
+		Sparkles,
 		Zap,
 		Rocket,
 		BookOpen,
@@ -61,7 +61,7 @@
 		<div class="hero-content" class:mounted>
 			<div class="hero-badge glass-subtle">
 				<span class="pulse">
-					<BotOff size={24} />
+					<Sparkles size={24} />
 				</span>
 				<span>MCP Retrieval Stack</span>
 			</div>

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,9 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M13.67 8H18a2 2 0 0 1 2 2v4.33"/>
-    <path d="M2 14h2"/>
-    <path d="M20 14h2"/>
-    <path d="M22 22 2 2"/>
-    <path d="M8 8H6a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h12a2 2 0 0 0 1.414-.586"/>
-    <path d="M9 13v2"/>
-    <path d="M9.67 4H12v2.33"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-sparkles-icon lucide-sparkles"><path d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"/><path d="M20 2v4"/><path d="M22 4h-4"/><circle cx="4" cy="20" r="2"/></svg>


### PR DESCRIPTION
- Replace BotOff icon with Sparkles in hero badge for more positive branding
- Update favicon.svg to match new Sparkles icon theme
- Maintain consistent visual identity across site and browser tab

Creates a more inviting and magical feel for the MCP Retrieval Stack while moving away from the 'disabled bot' visual metaphor.