### PR TITLE
feat: Add VS Code Extension button to landing page

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -148,6 +148,22 @@ body {
   }
 }
 
+// VS Code button with custom theme
+.btn-vscode {
+  background: rgba(0, 122, 204, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: var(--text-primary);
+  
+  &:hover {
+    background: rgba(0, 122, 204, 1);
+    border-color: rgba(255, 255, 255, 0.3);
+    box-shadow: 
+      0 8px 32px rgba(0, 122, 204, 0.4),
+      0 0 20px rgba(0, 122, 204, 0.2);
+    transform: translateY(-2px);
+  }
+}
+
 // Contact button with vibrant mail theme
 .btn-contact {
   background: linear-gradient(135deg, #3b82f6 0%, #6366f1 100%);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,7 +21,8 @@
 		Cpu,
 		Target,
 		Users,
-		Mail
+		Mail,
+		Puzzle
 	} from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { base } from '$app/paths';
@@ -91,6 +92,15 @@
 						/>
 					</svg>
 					View on GitHub
+				</a>
+
+				<a
+					href="https://marketplace.visualstudio.com/items?itemName=context-engine.context-engine-uploader"
+					class="btn-secondary btn-vscode"
+					target="_blank"
+				>
+					<Puzzle size={20} />
+					VS Code Extension
 				</a>
 
 				<a href="{base}/contact" class="btn-secondary btn-contact">


### PR DESCRIPTION
- Add VS Code Extension button between GitHub and Contact Us buttons
- Use Puzzle icon from lucide-svelte to represent extensions
- Style with VS Code brand blue theme and matching hover effects
- Include translateY(-2px) hover animation consistent with other buttons
- Link directly to marketplace for easy extension installation
- Maintain responsive layout for mobile/desktop compatibility