### PR TITLE
admin:  Add graph collection lifecycle support and improve admin logging

### DIFF
--- a/docs/CONFIG_DRIFT.md
+++ b/docs/CONFIG_DRIFT.md
@@ -12,6 +12,7 @@ This document tracks which environment/configuration knobs impact the indexing p
 | --- | --- | --- | --- |
 | `EMBEDDING_MODEL`, `EMBEDDING_PROVIDER` | Changes vector dimension/model space. | **Recreate** | Collection schema and stored vectors must match the embedding model; `ensure_collection()` recreates the collection when schema differs. |
 | `REFRAG_MODE`, `QWEN3_EMBEDDING_ENABLED`, `MINI_VEC_DIM`, `LEX_SPARSE_MODE` | Adds/removes named vectors (mini, sparse) and advanced embedding paths. | **Recreate** | Qdrant cannot add/remove vector names in-place; we back up → delete → recreate the collection to apply these changes. |
+| `INDEX_GRAPH_EDGES` | Enables/disables graph edge indexing for symbol relationships (defaults to enabled). | **Recreate** | Graph collections (`_graph` suffix) are created/deleted based on this setting; requires collection recreation. |
 | `INDEX_SEMANTIC_CHUNKS`, `INDEX_CHUNK_LINES`, `INDEX_CHUNK_OVERLAP` | Alters semantic chunk sizes/overlaps. | **Reindex** | Requires reprocessing every file so chunks align with the new geometry. |
 | `INDEX_MICRO_CHUNKS`, `MICRO_CHUNK_TOKENS`, `MICRO_CHUNK_STRIDE`, `MAX_MICRO_CHUNKS_PER_FILE` | Controls micro-chunk tier and token window. | **Reindex** | Points must be regenerated with the new token windows. |
 | `USE_TREE_SITTER`, `INDEX_USE_ENHANCED_AST` | Enables AST-guided segmentation + smart reindex logic. | **Reindex** | Cached symbols and chunk boundaries change; files need reindexing to stay consistent. |

--- a/scripts/admin_ui.py
+++ b/scripts/admin_ui.py
@@ -51,6 +51,7 @@ def render_admin_acl(
     deletion_enabled: bool = False,
     work_dir: str = "/work",
     refresh_ms: int = 5000,
+    flash: Optional[Dict[str, str]] = None,
     status_code: int = 200,
 ) -> Any:
     return _templates.TemplateResponse(
@@ -65,6 +66,7 @@ def render_admin_acl(
             "work_dir": work_dir,
             "staging_enabled": bool(is_staging_enabled() if callable(is_staging_enabled) else False),
             "refresh_ms": int(refresh_ms) if refresh_ms is not None else 5000,
+            "flash": flash,
         },
         status_code=status_code,
     )

--- a/scripts/collection_admin.py
+++ b/scripts/collection_admin.py
@@ -3,6 +3,7 @@ import json
 import re
 import shutil
 import time
+import logging
 from pathlib import Path
 from datetime import datetime
 from typing import Any, Dict, Optional, List
@@ -25,6 +26,14 @@ try:
     from scripts.workspace_state import get_collection_mappings
 except Exception:
     get_collection_mappings = None
+
+try:
+    from scripts.ingest.graph_edges import get_graph_collection_name
+except Exception:
+    get_graph_collection_name = None
+
+
+logger = logging.getLogger(__name__)
 
 
 _SLUGGED_REPO_RE = re.compile(r"^.+-[0-9a-f]{16}(?:_old)?$")
@@ -194,23 +203,45 @@ def delete_collection_everywhere(
         "collection": name,
         "qdrant_deleted": False,
         "registry_marked_deleted": False,
+        "graph_collection_deleted": False,
         "deleted_state_files": 0,
         "deleted_managed_workspaces": 0,
     }
 
     target_is_old = name.endswith("_old")
 
-    # 1) Delete Qdrant collection
+    # 1) Delete Qdrant collection and its associated graph collection
     try:
         if pooled_qdrant_client is not None:
             with pooled_qdrant_client(url=qdrant_url, api_key=os.environ.get("QDRANT_API_KEY")) as cli:
+                # Delete main collection
                 try:
                     cli.delete_collection(collection_name=name)
                     out["qdrant_deleted"] = True
-                except Exception:
+                except Exception as main_err:
                     out["qdrant_deleted"] = False
-    except Exception:
+                    logger.warning("[collection_admin] Failed to delete collection %s: %s", name, main_err)
+                    raise RuntimeError(f"Failed to delete collection {name}") from main_err
+
+                # Delete graph collection if it exists
+                if get_graph_collection_name is not None:
+                    graph_collection = get_graph_collection_name(name)
+                    try:
+                        cli.delete_collection(collection_name=graph_collection)
+                        out["graph_collection_deleted"] = True
+                    except Exception as graph_err:
+                        # Best-effort: graph collection might not exist
+                        out["graph_collection_deleted"] = False
+                        logger.warning(
+                            "[collection_admin] Failed to delete graph collection %s (best-effort): %s",
+                            graph_collection,
+                            graph_err,
+                        )
+    except Exception as delete_exc:
+        logger.error("[collection_admin] Error deleting collections %s: %s", name, delete_exc)
         out["qdrant_deleted"] = False
+        out["graph_collection_deleted"] = False
+        raise
 
     # 2) Mark deleted in registry DB
     try:

--- a/scripts/collection_admin.py
+++ b/scripts/collection_admin.py
@@ -229,8 +229,8 @@ def delete_collection_everywhere(
 
                 # Delete graph collection if it exists
                 if get_graph_collection_name is not None:
-                    graph_collection = get_graph_collection_name(name)
                     try:
+                        graph_collection = get_graph_collection_name(name)
                         cli.delete_collection(collection_name=graph_collection)
                         out["graph_collection_deleted"] = True
                     except Exception as graph_err:
@@ -238,7 +238,7 @@ def delete_collection_everywhere(
                         out["graph_collection_deleted"] = False
                         logger.warning(
                             "[collection_admin] Failed to delete graph collection %s (best-effort): %s",
-                            graph_collection,
+                            name if "graph_collection" not in locals() else graph_collection,
                             graph_err,
                         )
     except Exception as delete_exc:

--- a/scripts/indexing_admin.py
+++ b/scripts/indexing_admin.py
@@ -6,9 +6,10 @@ import subprocess
 import shutil
 import traceback
 import json
+import logging
 from pathlib import Path
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 try:
     from qdrant_client import QdrantClient
@@ -71,6 +72,21 @@ except Exception:
     promote_pending_indexing_config = None  # type: ignore
     persist_indexing_config = None  # type: ignore
 
+logger = logging.getLogger(__name__)
+
+try:
+    from scripts.ingest.graph_edges import get_graph_collection_name
+except Exception:
+    get_graph_collection_name = None  # type: ignore
+
+if not callable(get_graph_collection_name):
+    logger.warning(
+        "Graph edge helpers unavailable; graph collections will not be cloned or cleaned up during staging"
+    )
+get_graph_collection_name_t: Optional[Callable[[str], str]] = (
+    get_graph_collection_name if callable(get_graph_collection_name) else None
+)
+
 
 def _staging_enabled() -> bool:
     return bool(is_staging_enabled() if callable(is_staging_enabled) else False)
@@ -132,7 +148,7 @@ def _copy_repo_state_for_clone(
             with cache_path.open("w", encoding="utf-8") as fh:
                 json.dump(cache, fh, ensure_ascii=False, indent=2, sort_keys=True)
     except Exception as exc:
-        print(f"[staging] Warning: failed to retarget cache.json for {clone_repo_name}: {exc}")
+        logger.warning("[staging] failed to retarget cache.json for %s: %s", clone_repo_name, exc)
 
 
 _COLLECTION_SCHEMA_CACHE: Dict[str, Dict[str, Any]] = {}
@@ -328,12 +344,7 @@ def _auto_refresh_snapshot_if_needed(
                 pending=True,
             )
         except Exception as exc:
-            try:
-                print(
-                    f"[snapshot_refresh] Failed to capture pending config for {collection}: {exc}"
-                )
-            except Exception:
-                pass
+            logger.warning("[snapshot_refresh] Failed to capture pending config for %s: %s", collection, exc)
             return False
 
     dry_run = str(os.environ.get("CTXCE_SNAPSHOT_REFRESH_DRY_RUN", "0")).strip().lower() in {
@@ -345,30 +356,26 @@ def _auto_refresh_snapshot_if_needed(
 
     try:
         if dry_run:
-            print(
-                f"[snapshot_refresh] DRY RUN: would promote pending config for {collection} "
-                f"(workspace={ws}, repo={repo_name or 'default'}) after validating schema: "
-                f"{', '.join(snapshot_only_keys)}"
+            logger.info(
+                "[snapshot_refresh] DRY RUN: would promote pending config for %s (workspace=%s, repo=%s) after validating schema: %s",
+                collection,
+                ws,
+                repo_name or "default",
+                ", ".join(snapshot_only_keys),
             )
             return True
         promote_pending_indexing_config(workspace_path=ws, repo_name=repo_name)
         _SNAPSHOT_REFRESHED.add(cache_key)
-        try:
-            print(
-                f"[snapshot_refresh] promoted pending indexing config for {collection} "
-                f"(workspace={ws}, repo={repo_name or 'default'}) after validating schema: "
-                f"{', '.join(snapshot_only_keys)}"
-            )
-        except Exception:
-            pass
+        logger.info(
+            "[snapshot_refresh] promoted pending indexing config for %s (workspace=%s, repo=%s) after validating schema: %s",
+            collection,
+            ws,
+            repo_name or "default",
+            ", ".join(snapshot_only_keys),
+        )
         return True
     except Exception as exc:
-        try:
-            print(
-                f"[snapshot_refresh] Failed to promote indexing config for {collection}: {exc}"
-            )
-        except Exception:
-            pass
+        logger.warning("[snapshot_refresh] Failed to promote indexing config for %s: %s", collection, exc)
         return False
 
 
@@ -406,6 +413,41 @@ def _delete_path_tree(p: Path) -> bool:
         return True
     except Exception:
         return False
+
+
+def _delete_collection_and_graph(collection_name: str) -> None:
+    if QdrantClient is None:
+        return
+    name = (collection_name or "").strip()
+    if not name:
+        return
+    qdrant_url = os.environ.get("QDRANT_URL", "http://qdrant:6333")
+    api_key = os.environ.get("QDRANT_API_KEY") or None
+    try:
+        client = QdrantClient(url=qdrant_url, api_key=api_key)
+    except Exception:
+        return
+    try:
+        try:
+            client.delete_collection(collection_name=name)
+        except Exception:
+            pass
+
+        if get_graph_collection_name_t is not None:
+            graph_name = get_graph_collection_name_t(name)
+            try:
+                client.delete_collection(collection_name=graph_name)
+            except Exception as graph_err:
+                logger.warning(
+                    "[staging] Failed to delete graph collection %s (best-effort): %s",
+                    graph_name,
+                    graph_err,
+                )
+    finally:
+        try:
+            client.close()
+        except Exception:
+            pass
 
 
 def _resolve_codebase_root(work_root: Path) -> Path:
@@ -447,14 +489,7 @@ def _cleanup_old_clone(
 
     old_collection = f"{collection}_old"
     if delete_collection:
-        try:
-            delete_collection_qdrant(
-                qdrant_url=os.environ.get("QDRANT_URL", "http://qdrant:6333"),
-                api_key=os.environ.get("QDRANT_API_KEY") or None,
-                collection=old_collection,
-            )
-        except Exception:
-            pass
+        _delete_collection_and_graph(old_collection)
 
     if not repo_name:
         return
@@ -486,12 +521,11 @@ def _cleanup_old_clone(
                 return resolved_candidate
         except Exception:
             pass
-        try:
-            print(
-                f"[staging] refusing to treat {resolved_candidate} as work root; falling back to {resolved_base}"
-            )
-        except Exception:
-            pass
+        logger.warning(
+            "[staging] refusing to treat %s as work root; falling back to %s",
+            resolved_candidate,
+            resolved_base,
+        )
         return resolved_base
 
     work_root: Optional[Path] = None
@@ -529,7 +563,11 @@ def _cleanup_old_clone(
             if resolved_base == resolved_target or resolved_base in resolved_target.parents:
                 _delete_path_tree(resolved_target)
             else:
-                print(f"[staging] refusing to delete {resolved_target}: outside work root {resolved_base}")
+                logger.warning(
+                    "[staging] refusing to delete %s: outside work root %s",
+                    resolved_target,
+                    resolved_base,
+                )
         except Exception:
             pass
 
@@ -561,6 +599,7 @@ CONFIG_DRIFT_RULES: Dict[str, str] = {
     "qwen3_embedding_enabled": "recreate",
     "mini_vec_dim": "recreate",
     "lex_sparse_mode": "recreate",
+    "index_graph_edges": "recreate",
     # Chunking / AST changes
     "index_semantic_chunks": "reindex",
     "index_chunk_lines": "reindex",
@@ -589,6 +628,7 @@ _INDEXING_CONFIG_DEFAULTS: Dict[str, Any] = {
     "index_use_enhanced_ast": False,
     "mini_vec_dim": None,
     "lex_sparse_mode": False,
+    "index_graph_edges": True,
 }
 
 
@@ -823,6 +863,8 @@ def build_admin_collections_view(*, collections: Any, work_dir: str) -> List[Dic
         staging_status = "none"
         staging_collection = ""
         staging_state = ""
+        graph_clone_name = ""
+        graph_clone_copied = False
         if st:
             try:
                 staging_info = st.get("staging") or {}
@@ -832,10 +874,25 @@ def build_admin_collections_view(*, collections: Any, work_dir: str) -> List[Dic
                     staging_status_info = staging_info.get("status") or {}
                     if isinstance(staging_status_info, dict):
                         staging_state = str(staging_status_info.get("state") or "")
+                    graph_clone_info = staging_info.get("graph_clone") or {}
+                    if isinstance(graph_clone_info, dict):
+                        graph_clone_name = str(graph_clone_info.get("name") or "")
+                        graph_clone_copied = bool(graph_clone_info.get("copied"))
                 else:
                     staging_status = "none"
             except Exception:
                 staging_status = "none"
+
+        index_graph_edges_enabled: Optional[bool] = None
+        if applied_config:
+            try:
+                val = applied_config.get("index_graph_edges")
+                if isinstance(val, bool):
+                    index_graph_edges_enabled = val
+                elif isinstance(val, str):
+                    index_graph_edges_enabled = val.lower() in {"1", "true", "yes", "on"}
+            except Exception:
+                index_graph_edges_enabled = None
 
         # "maintenance needed" should reflect actual config drift requiring a maintenance reindex.
         # Pending hashes can exist during staging / queued rebuild flows; keep them visible in the UI
@@ -909,6 +966,9 @@ def build_admin_collections_view(*, collections: Any, work_dir: str) -> List[Dic
                 "staging_status": staging_status,
                 "staging_collection": staging_collection,
                 "staging_state": staging_state,
+                "graph_clone_name": graph_clone_name,
+                "graph_clone_copied": graph_clone_copied,
+                "index_graph_edges_enabled": index_graph_edges_enabled,
             }
         )
 
@@ -951,6 +1011,21 @@ def recreate_collection_qdrant(*, qdrant_url: str, api_key: Optional[str], colle
             cli.delete_collection(collection_name=name)
         except Exception as delete_error:
             raise RuntimeError(f"Failed to delete existing collection '{name}' in Qdrant: {delete_error}") from delete_error
+
+        # Also delete the graph collection if it exists
+        # Graph collections are tightly coupled to their main collection
+        # The decision to recreate happens during ingest (based on INDEX_GRAPH_EDGES)
+        if get_graph_collection_name_t is not None:
+            graph_name = get_graph_collection_name_t(name)
+            try:
+                cli.delete_collection(collection_name=graph_name)
+            except Exception as graph_error:
+                # Best-effort: don't fail main recreation if graph deletion fails
+                logger.warning(
+                    "Failed to delete graph collection '%s' (non-critical): %s",
+                    graph_name,
+                    graph_error,
+                )
     finally:
         try:
             cli.close()
@@ -1061,10 +1136,7 @@ def _normalize_cloned_collection_schema(*, collection_name: str, qdrant_url: str
         if ensure_payload_indexes is not None:
             ensure_payload_indexes(client, collection_name)
     except Exception as exc:
-        try:
-            print(f"[staging] Warning: failed to normalize cloned collection {collection_name}: {exc}")
-        except Exception:
-            pass
+        logger.warning("[staging] failed to normalize cloned collection %s: %s", collection_name, exc)
     finally:
         try:
             client.close()
@@ -1121,13 +1193,12 @@ def _wait_for_clone_points(
                 clone_count = 0
 
             if clone_count >= expected_count:
-                try:
-                    print(
-                        f"[staging] Clone verification succeeded: {cloned_collection} has "
-                        f"{clone_count} points (expected >= {expected_count})."
-                    )
-                except Exception:
-                    pass
+                logger.info(
+                    "[staging] Clone verification succeeded: %s has %s points (expected >= %s)",
+                    cloned_collection,
+                    clone_count,
+                    expected_count,
+                )
                 return
 
             if time.time() > deadline:
@@ -1178,28 +1249,64 @@ def start_staging_rebuild(*, collection: str, work_dir: str) -> str:
         raise RuntimeError("copy_collection_qdrant unavailable (import failed)")
 
     try:
-        print(f"[staging] Copying collection {collection} -> {old_collection} (overwrite=True)")
-        try:
-            print(
-                f"[staging] copy_collection_qdrant callable={callable(_copy_fn)} type={type(_copy_fn)} module={getattr(_copy_fn, '__module__', '?')}"
-            )
-        except Exception:
-            pass
+        logger.info("[staging] Copying collection %s -> %s (overwrite=True)", collection, old_collection)
+        logger.debug(
+            "[staging] copy_collection_qdrant callable=%s type=%s module=%s",
+            callable(_copy_fn),
+            type(_copy_fn),
+            getattr(_copy_fn, "__module__", "?"),
+        )
         _copy_fn(
             source=collection,
             target=old_collection,
             qdrant_url=qdrant_url,
             overwrite=True,
         )
-        print(f"[staging] Copy completed for {old_collection}")
+        logger.info("[staging] Copy completed for %s", old_collection)
     except Exception as exc:
-        print(f"[staging] ERROR copying {collection} -> {old_collection}: {exc!r}")
-        try:
-            print("[staging] TRACEBACK (copy)")
-            print(traceback.format_exc())
-        except Exception:
-            pass
+        logger.error("[staging] ERROR copying %s -> %s: %s", collection, old_collection, exc)
+        logger.debug("[staging] TRACEBACK (copy)\n%s", traceback.format_exc())
         raise
+
+    graph_clone_details: Dict[str, Any] = {"copied": False, "name": None}
+    # Copy graph collection if it exists (best-effort)
+    try:
+        if get_graph_collection_name_t is not None:
+            graph_collection = get_graph_collection_name_t(collection)
+            old_graph_collection = get_graph_collection_name_t(old_collection)
+            graph_clone_details["name"] = old_graph_collection
+            logger.info(
+                "[staging] Copying graph collection %s -> %s (best-effort)",
+                graph_collection,
+                old_graph_collection,
+            )
+            try:
+                _copy_fn(
+                    source=graph_collection,
+                    target=old_graph_collection,
+                    qdrant_url=qdrant_url,
+                    overwrite=True,
+                )
+                graph_clone_details["copied"] = True
+                logger.info("[staging] Graph collection copy completed for %s", old_graph_collection)
+            except Exception as graph_exc:
+                # Graph collection copy is best-effort - log warning but don't fail staging
+                err_str = str(graph_exc).lower()
+                if "404" in err_str or "doesn't exist" in err_str or "not found" in err_str:
+                    logger.info(
+                        "[staging] Graph collection %s not found while copying: %s",
+                        graph_collection,
+                        graph_exc,
+                    )
+                else:
+                    logger.warning(
+                        "[staging] Failed to copy graph collection %s -> %s: %s",
+                        graph_collection,
+                        old_graph_collection,
+                        graph_exc,
+                    )
+    except Exception as exc:
+        logger.warning("[staging] Graph collection copy skipped: %s", exc)
 
     try:
         _wait_for_clone_points(
@@ -1210,13 +1317,13 @@ def start_staging_rebuild(*, collection: str, work_dir: str) -> str:
             timeout_seconds=90,
         )
     except Exception as exc:
-        print(f"[staging] ERROR verifying clone {old_collection}: {exc}")
+        logger.error("[staging] ERROR verifying clone %s: %s", old_collection, exc)
         raise
 
     # IMPORTANT: switch serving to *_old as soon as the clone is verified.
     # Large repos can make the filesystem copy below slow; don't block the traffic cutover.
     try:
-        print(f"[staging] Switching serving to clone {old_collection}")
+        logger.info("[staging] Switching serving to clone %s", old_collection)
         update_workspace_state(
             workspace_path=root,
             repo_name=repo_name,
@@ -1228,14 +1335,14 @@ def start_staging_rebuild(*, collection: str, work_dir: str) -> str:
             },
         )
     except Exception as exc:
-        print(f"[staging] ERROR updating serving state to {old_collection}: {exc}")
+        logger.error("[staging] ERROR updating serving state to %s: %s", old_collection, exc)
         raise
 
     # Best-effort: ensure payload indexes on the clone. Failures here must not break cutover.
     try:
         _normalize_cloned_collection_schema(collection_name=old_collection, qdrant_url=qdrant_url)
     except Exception as exc:
-        print(f"[staging] Warning: failed to normalize cloned collection {old_collection}: {exc}")
+        logger.warning("[staging] failed to normalize cloned collection %s: %s", old_collection, exc)
 
     # Duplicate workspace slug/state to <slug>_old so watcher/indexer can serve reads from the clone.
     # This can be slow for large repos; treat as best-effort and do not block staging cutover.
@@ -1246,11 +1353,11 @@ def start_staging_rebuild(*, collection: str, work_dir: str) -> str:
         try:
             if canonical_dir.exists():
                 t0 = time.time()
-                print(f"[staging] Copying workspace tree {canonical_dir} -> {old_dir}")
+                logger.info("[staging] Copying workspace tree %s -> %s", canonical_dir, old_dir)
                 shutil.copytree(canonical_dir, old_dir, dirs_exist_ok=True)
-                print(f"[staging] Workspace copy completed in {time.time() - t0:.1f}s")
+                logger.info("[staging] Workspace copy completed in %.1fs", time.time() - t0)
         except Exception as exc:
-            print(f"[staging] Warning: failed to copy workspace tree for {repo_name}: {exc}")
+            logger.warning("[staging] failed to copy workspace tree for %s: %s", repo_name, exc)
 
         try:
             _copy_repo_state_for_clone(
@@ -1260,7 +1367,7 @@ def start_staging_rebuild(*, collection: str, work_dir: str) -> str:
                 clone_workspace=str(old_dir),
             )
         except Exception as exc:
-            print(f"[staging] Warning: failed to copy repo state for {repo_name}: {exc}")
+            logger.warning("[staging] failed to copy repo state for %s: %s", repo_name, exc)
 
         try:
             old_state = state.copy()
@@ -1283,7 +1390,7 @@ def start_staging_rebuild(*, collection: str, work_dir: str) -> str:
                 updates=old_state,
             )
         except Exception as exc:
-            print(f"[staging] Warning: failed to write *_old state for {repo_name}: {exc}")
+            logger.warning("[staging] failed to write *_old state for %s: %s", repo_name, exc)
 
     # Prepare canonical slug for rebuild (pending env)
     pending_cfg = state.get("indexing_config_pending") or state.get("indexing_config")
@@ -1309,6 +1416,11 @@ def start_staging_rebuild(*, collection: str, work_dir: str) -> str:
             "workspace_path": root,
             "repo_name": repo_name,
         }
+        if graph_clone_details["name"]:
+            staging_info["graph_clone"] = {
+                "name": graph_clone_details["name"],
+                "copied": graph_clone_details["copied"],
+            }
         set_staging_state(workspace_path=root, repo_name=repo_name, staging=staging_info)
 
     if update_staging_status:

--- a/scripts/indexing_admin.py
+++ b/scripts/indexing_admin.py
@@ -168,6 +168,9 @@ def _probe_collection_schema(collection: str) -> Optional[Dict[str, Any]]:
 
     qdrant_url = os.environ.get("QDRANT_URL", "http://qdrant:6333")
     api_key = os.environ.get("QDRANT_API_KEY") or None
+    if QdrantClient is None:
+        return
+
     try:
         client = QdrantClient(url=qdrant_url, api_key=api_key)
     except Exception as e:
@@ -430,13 +433,30 @@ def _delete_path_tree(p: Path) -> bool:
 
 
 def _delete_collection_and_graph(collection_name: str) -> None:
-    if QdrantClient is None:
-        return
     name = (collection_name or "").strip()
     if not name:
         return
     qdrant_url = os.environ.get("QDRANT_URL", "http://qdrant:6333")
     api_key = os.environ.get("QDRANT_API_KEY") or None
+
+    # Prefer existing helper so tests that monkeypatch delete_collection_qdrant can observe calls.
+    if callable(delete_collection_qdrant):
+        try:
+            delete_collection_qdrant(qdrant_url=qdrant_url, api_key=api_key, collection=name)
+        except Exception as exc:
+            logger.warning("[staging] Failed to delete collection %s: %s", name, exc)
+        if get_graph_collection_name_t is not None:
+            graph_name = get_graph_collection_name_t(name)
+            try:
+                delete_collection_qdrant(qdrant_url=qdrant_url, api_key=api_key, collection=graph_name)
+            except Exception as graph_err:
+                logger.warning(
+                    "[staging] Failed to delete graph collection %s (best-effort): %s",
+                    graph_name,
+                    graph_err,
+                )
+        return
+
     try:
         client = QdrantClient(url=qdrant_url, api_key=api_key)
     except Exception:

--- a/scripts/upload_delta_bundle.py
+++ b/scripts/upload_delta_bundle.py
@@ -191,6 +191,14 @@ def process_delta_bundle(workspace_path: str, bundle_path: Path, manifest: Dict[
             except Exception as e:
                 logger.debug(f"Suppressed exception: {e}")
 
+        if not slug_order:
+            fallback_leaf = Path(workspace_path).name or "workspace"
+            if _SLUGGED_REPO_RE.match(fallback_leaf):
+                slug_order.append(fallback_leaf)
+            else:
+                workspace_key = get_workspace_key(workspace_path)
+                slug_order.append(f"{fallback_leaf}-{workspace_key}")
+
         replica_roots: Dict[str, Path] = {}
         for slug in slug_order:
             path = Path(WORK_DIR) / slug

--- a/scripts/upload_service.py
+++ b/scripts/upload_service.py
@@ -44,6 +44,7 @@ import uvicorn
 from fastapi import FastAPI, File, UploadFile, Form, HTTPException, Request, status
 from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.middleware.cors import CORSMiddleware
+from urllib.parse import urlencode
 
 from scripts.upload_delta_bundle import get_workspace_key, process_delta_bundle
 
@@ -711,6 +712,21 @@ async def admin_acl_page(request: Request):
         build_admin_collections_view, collections=collections, work_dir=WORK_DIR
     )
 
+    flash: Optional[Dict[str, str]] = None
+    deleted = request.query_params.get("deleted")
+    if deleted:
+        graph_flag = request.query_params.get("graph_deleted")
+        if graph_flag == "1":
+            message = f"Collection {deleted} and its graph clone were deleted."
+            level = "success"
+        elif graph_flag == "0":
+            message = f"Collection {deleted} was deleted. Graph clone was not found or could not be deleted."
+            level = "warning"
+        else:
+            message = f"Collection {deleted} was deleted."
+            level = "success"
+        flash = {"message": message, "level": level}
+
     resp = render_admin_acl(
         request,
         users=users,
@@ -719,6 +735,7 @@ async def admin_acl_page(request: Request):
         deletion_enabled=ADMIN_COLLECTION_DELETE_ENABLED,
         work_dir=WORK_DIR,
         refresh_ms=ADMIN_COLLECTION_REFRESH_MS,
+        flash=flash,
     )
     candidate = _get_session_candidate_from_request(request)
     if candidate.get("source") and candidate.get("source") != "cookie":
@@ -935,7 +952,7 @@ async def admin_delete_collection(
         cleanup_fs = False
 
     try:
-        delete_collection_everywhere(
+        delete_result = delete_collection_everywhere(
             collection=name,
             work_dir=WORK_DIR,
             qdrant_url=QDRANT_URL,
@@ -949,7 +966,21 @@ async def admin_delete_collection(
             back_href="/admin/acl",
         )
 
-    return RedirectResponse(url="/admin/acl", status_code=302)
+    query_params = {"deleted": name}
+    graph_deleted = None
+    if isinstance(delete_result, dict):
+        value = delete_result.get("graph_collection_deleted")
+        if value is True:
+            graph_deleted = "1"
+        elif value is False:
+            graph_deleted = "0"
+    if graph_deleted is not None:
+        query_params["graph_deleted"] = graph_deleted
+
+    redirect_url = "/admin/acl"
+    if query_params:
+        redirect_url = f"{redirect_url}?{urlencode(query_params)}"
+    return RedirectResponse(url=redirect_url, status_code=302)
 
 
 @app.post("/admin/staging/start")

--- a/scripts/workspace_state.py
+++ b/scripts/workspace_state.py
@@ -1886,6 +1886,7 @@ def get_indexing_config_snapshot() -> Dict[str, Any]:
         "index_use_enhanced_ast": _env_truthy("INDEX_USE_ENHANCED_AST", False),
         "mini_vec_dim": _env_int("MINI_VEC_DIM"),
         "lex_sparse_mode": _env_truthy("LEX_SPARSE_MODE", False),
+        "index_graph_edges": _env_truthy("INDEX_GRAPH_EDGES", True),
     }
 
 

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -12,6 +12,10 @@
       .card { border: 1px solid #ddd; border-radius: 8px; padding: 16px; margin-top: 12px; }
       .error { color: #b00; }
       .warning { color: #8a6d3b; }
+      .flash { border-radius: 6px; padding: 10px 14px; margin: 12px 0; font-size: 14px; }
+      .flash.success { background: #e6f4ea; color: #1e7b34; border: 1px solid #b8e0c3; }
+      .flash.warning { background: #fff7e6; color: #8a6d3b; border: 1px solid #f2d6a0; }
+      .flash.error { background: #fdecea; color: #b3261e; border: 1px solid #f5a29a; }
       table { border-collapse: collapse; width: 100%; }
       th, td { border: 1px solid #ddd; padding: 6px 8px; text-align: left; }
       th { background: #f7f7f7; }
@@ -33,6 +37,10 @@
         </form>
       </nav>
     </header>
+
+    {% if flash and flash.message %}
+      <div class="flash {{ flash.level or '' }}">{{ flash.message }}</div>
+    {% endif %}
 
     {% block content %}{% endblock %}
 

--- a/tests/test_admin_collection_delete.py
+++ b/tests/test_admin_collection_delete.py
@@ -1,8 +1,19 @@
 import importlib
+import os
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from fastapi.testclient import TestClient
 from starlette.responses import Response
+
+try:
+    from qdrant_client.http.exceptions import UnexpectedResponse
+except Exception:
+    class UnexpectedResponse(Exception):
+        def __init__(self, status_code: int, reason_phrase: str):
+            self.status_code = status_code
+            self.reason_phrase = reason_phrase
+
 
 
 @pytest.mark.unit
@@ -27,7 +38,7 @@ def test_env_gate_blocks_delete_endpoint(monkeypatch):
 
     monkeypatch.setattr(srv, "delete_collection_everywhere", _should_not_be_called)
 
-    client = TestClient(srv.app)
+    client = TestClient(srv.app, follow_redirects=False)
     resp = client.post("/admin/collections/delete", data={"collection": "c1", "delete_fs": ""})
     assert resp.status_code == 403
 
@@ -46,7 +57,7 @@ def test_admin_role_gate_blocks_non_admin(monkeypatch):
     monkeypatch.setattr(srv, "_get_valid_session_record", lambda _req: {"user_id": "u1"})
     monkeypatch.setattr(srv, "is_admin_user", lambda _uid: False)
 
-    client = TestClient(srv.app)
+    client = TestClient(srv.app, follow_redirects=False)
     resp = client.post("/admin/collections/delete", data={"collection": "c1"})
     assert resp.status_code == 403
     assert resp.json().get("detail") == "Admin required"
@@ -177,3 +188,177 @@ def test_workspace_state_does_not_recreate_repo_metadata_when_workspace_missing(
 
     ws.log_activity(repo_name=repo_name, action="deleted", workspace_path=str(ws_root))
     assert not state_dir.exists()
+
+
+@pytest.mark.unit
+def test_delete_collection_everywhere_deletes_graph_collection(monkeypatch, tmp_path):
+    """Test that graph collection is deleted with main collection."""
+    ca = importlib.import_module("scripts.collection_admin")
+    ca = importlib.reload(ca)
+
+    deleted_collections = []
+    env_enabled = os.environ.get("CTXCE_ADMIN_COLLECTION_DELETE_ENABLED")
+    monkeypatch.setenv("CTXCE_ADMIN_COLLECTION_DELETE_ENABLED", "1")
+
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def delete_collection(self, collection_name):
+            deleted_collections.append(collection_name)
+
+    def fake_pooled_qdrant_client(**kwargs):
+        return FakeClient()
+
+    def fake_get_graph_collection_name(base_collection: str) -> str:
+        return f"{base_collection}_graph"
+
+    monkeypatch.setattr(ca, "pooled_qdrant_client", fake_pooled_qdrant_client)
+    monkeypatch.setattr(ca, "get_graph_collection_name", fake_get_graph_collection_name)
+    monkeypatch.setattr(ca, "_cleanup_state_files_for_mapping", lambda **_: 1)
+    monkeypatch.setattr(ca, "_is_managed_upload_workspace_dir", lambda **_: False)
+    monkeypatch.setattr(ca, "get_collection_mappings", lambda **_: [])
+
+    try:
+        # Call delete_collection_everywhere
+        result = ca.delete_collection_everywhere(collection="my_collection", cleanup_fs=False)
+
+        # Verify both main and graph collections deleted
+        assert "my_collection" in deleted_collections, "Expected main collection to be deleted"
+        assert "my_collection_graph" in deleted_collections, "Expected graph collection to be deleted"
+        assert result.get("graph_collection_deleted") is True, "Expected graph_collection_deleted to be True"
+    finally:
+        if env_enabled is None:
+            monkeypatch.delenv("CTXCE_ADMIN_COLLECTION_DELETE_ENABLED", raising=False)
+        else:
+            monkeypatch.setenv("CTXCE_ADMIN_COLLECTION_DELETE_ENABLED", env_enabled)
+
+
+@pytest.mark.unit
+def test_delete_endpoint_redirects_with_graph_flag(monkeypatch):
+    monkeypatch.setenv("CTXCE_AUTH_ENABLED", "1")
+    monkeypatch.setenv("CTXCE_ADMIN_COLLECTION_DELETE_ENABLED", "1")
+
+    srv = importlib.import_module("scripts.upload_service")
+    srv = importlib.reload(srv)
+
+    monkeypatch.setattr(srv, "_require_admin_session", lambda _request: {"user_id": "admin"})
+    monkeypatch.setattr(srv, "delete_collection_everywhere", lambda **_: {"graph_collection_deleted": True})
+
+    client = TestClient(srv.app, follow_redirects=False)
+    resp = client.post("/admin/collections/delete", data={"collection": "c1"})
+
+    assert resp.status_code == 302
+    location = resp.headers.get("location")
+    assert location, "Expected redirect location header"
+    parsed = urlparse(location)
+    assert parsed.path == "/admin/acl"
+    qs = parse_qs(parsed.query)
+    assert qs.get("deleted") == ["c1"]
+    assert qs.get("graph_deleted") == ["1"]
+
+
+@pytest.mark.unit
+def test_admin_acl_flash_message(monkeypatch):
+    monkeypatch.setenv("CTXCE_AUTH_ENABLED", "1")
+    monkeypatch.setenv("CTXCE_ADMIN_COLLECTION_DELETE_ENABLED", "1")
+
+    srv = importlib.import_module("scripts.upload_service")
+    srv = importlib.reload(srv)
+
+    monkeypatch.setattr(srv, "_require_admin_session", lambda _request: {"user_id": "admin"})
+    monkeypatch.setattr(srv, "list_users", lambda: [])
+    monkeypatch.setattr(srv, "list_collections", lambda **_: [])
+    monkeypatch.setattr(srv, "list_collection_acl", lambda: [])
+    monkeypatch.setattr(srv, "build_admin_collections_view", lambda **_: [])
+
+    client = TestClient(srv.app)
+    resp = client.get("/admin/acl?deleted=c1&graph_deleted=0")
+
+    assert resp.status_code == 200
+    assert "graph clone was not found or could not be deleted" in resp.text.lower()
+
+
+@pytest.mark.unit
+def test_admin_collections_status_endpoint(monkeypatch):
+    monkeypatch.setenv("CTXCE_AUTH_ENABLED", "1")
+
+    srv = importlib.import_module("scripts.upload_service")
+    srv = importlib.reload(srv)
+
+    monkeypatch.setattr(srv, "_require_admin_session", lambda _request: {"user_id": "admin"})
+    monkeypatch.setattr(srv, "list_collections", lambda **_: [
+        {"id": 1, "qdrant_collection": "c1", "created_at": 0, "is_deleted": 0}
+    ])
+    monkeypatch.setattr(
+        srv,
+        "build_admin_collections_view",
+        lambda **_: [{"qdrant_collection": "c1", "graph_clone_name": "c1_graph"}],
+    )
+
+    client = TestClient(srv.app)
+    resp = client.get("/admin/collections/status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data.get("collections"), list)
+    assert data["collections"][0]["qdrant_collection"] == "c1"
+
+
+@pytest.mark.unit
+def test_delete_collection_succeeds_without_graph_collection(monkeypatch, tmp_path):
+    """Test that delete succeeds when graph collection doesn't exist."""
+    ca = importlib.import_module("scripts.collection_admin")
+    ca = importlib.reload(ca)
+
+    deleted_collections = []
+    env_enabled = os.environ.get("CTXCE_ADMIN_COLLECTION_DELETE_ENABLED")
+
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def delete_collection(self, collection_name):
+            deleted_collections.append(collection_name)
+            # Simulate that the main collection exists but graph doesn't
+            if "_graph" in collection_name:
+                from qdrant_client.http.exceptions import UnexpectedResponse
+                raise UnexpectedResponse(
+                    status_code=404,
+                    reason_phrase="Not Found",
+                )
+
+    def fake_pooled_qdrant_client(**kwargs):
+        return FakeClient()
+
+    def fake_get_graph_collection_name(base_collection: str) -> str:
+        return f"{base_collection}_graph"
+
+    monkeypatch.setenv("CTXCE_ADMIN_COLLECTION_DELETE_ENABLED", "1")
+    monkeypatch.setattr(ca, "pooled_qdrant_client", fake_pooled_qdrant_client)
+    monkeypatch.setattr(ca, "get_graph_collection_name", fake_get_graph_collection_name)
+    monkeypatch.setattr(ca, "_cleanup_state_files_for_mapping", lambda **_: 1)
+    monkeypatch.setattr(ca, "_is_managed_upload_workspace_dir", lambda **_: False)
+    monkeypatch.setattr(ca, "get_collection_mappings", lambda **_: [])
+
+    try:
+        # Call delete_collection_everywhere - should not fail even if graph doesn't exist
+        result = ca.delete_collection_everywhere(collection="my_collection", cleanup_fs=False)
+
+        # Verify main collection was deleted
+        assert "my_collection" in deleted_collections, "Expected main collection to be deleted"
+        # Graph delete was attempted even though Qdrant responded 404
+        assert "my_collection_graph" in deleted_collections, "Graph collection delete should be attempted even if it fails"
+        # The function should succeed even if graph deletion fails
+        assert result.get("qdrant_deleted") is True, "Expected main collection to be deleted"
+    finally:
+        if env_enabled is None:
+            monkeypatch.delenv("CTXCE_ADMIN_COLLECTION_DELETE_ENABLED", raising=False)
+        else:
+            monkeypatch.setenv("CTXCE_ADMIN_COLLECTION_DELETE_ENABLED", env_enabled)

--- a/tests/test_admin_collection_delete.py
+++ b/tests/test_admin_collection_delete.py
@@ -328,7 +328,6 @@ def test_delete_collection_succeeds_without_graph_collection(monkeypatch, tmp_pa
             deleted_collections.append(collection_name)
             # Simulate that the main collection exists but graph doesn't
             if "_graph" in collection_name:
-                from qdrant_client.http.exceptions import UnexpectedResponse
                 raise UnexpectedResponse(
                     status_code=404,
                     reason_phrase="Not Found",

--- a/tests/test_staging_lifecycle.py
+++ b/tests/test_staging_lifecycle.py
@@ -116,6 +116,9 @@ def test_staging_start_promote_activate_and_abort_are_consistent(
         "normalize_schema": 0,
     }
 
+    def fake_get_graph_collection_name(base_collection: str) -> str:
+        return f"{base_collection}_graph"
+
     def fake_mapping_index(*, work_dir: str):
         return {
             collection: [
@@ -148,6 +151,7 @@ def test_staging_start_promote_activate_and_abort_are_consistent(
     def fake_normalize_cloned_collection_schema(**kwargs):
         calls["normalize_schema"] += 1
 
+    monkeypatch.setattr(indexing_admin, "get_graph_collection_name", fake_get_graph_collection_name)
     monkeypatch.setattr(indexing_admin, "copy_collection_qdrant", fake_copy_collection_qdrant)
     monkeypatch.setattr(indexing_admin, "recreate_collection_qdrant", fake_recreate_collection_qdrant)
     monkeypatch.setattr(indexing_admin, "spawn_ingest_code", fake_spawn_ingest_code)
@@ -165,6 +169,12 @@ def test_staging_start_promote_activate_and_abort_are_consistent(
     assert calls["copy"], "Expected copy_collection_qdrant to be called"
     assert calls["copy"][0]["source"] == collection
     assert calls["copy"][0]["target"] == old_collection
+
+    # Contract: copy_collection_qdrant called for graph -> _old_graph (best-effort).
+    assert len(calls["copy"]) >= 2, "Expected copy_collection_qdrant to be called for graph collection"
+    graph_copy = next((c for c in calls["copy"] if c.get("source") == f"{collection}_graph"), None)
+    assert graph_copy is not None, "Expected graph collection to be copied"
+    assert graph_copy["target"] == f"{old_collection}_graph"
 
     # Contract: workspace clone dir exists.
     assert (root / f"{repo_name}_old").exists()
@@ -221,6 +231,9 @@ def test_staging_start_promote_activate_and_abort_are_consistent(
 
     # Contract: _old collection delete invoked.
     assert any(d.get("collection") == old_collection for d in calls["delete"])
+
+    # Contract: _old_graph collection delete invoked (best-effort).
+    assert any(d.get("collection") == f"{old_collection}_graph" for d in calls["delete"])
 
     # Idempotent activate
     indexing_admin.activate_staging_rebuild(collection=collection, work_dir=str(root))
@@ -802,3 +815,157 @@ def test_watcher_collection_reuse_logical_repo(monkeypatch: pytest.MonkeyPatch, 
     coll = watch_utils._get_collection_for_repo(repo_path)
     assert coll == "reuse-coll"
     assert updates and updates[0]["updates"]["qdrant_collection"] == "reuse-coll"
+
+
+def test_staging_start_copies_graph_collection(staging_workspace: dict, monkeypatch: pytest.MonkeyPatch):
+    """Test that graph collection is copied during staging start."""
+    from scripts import indexing_admin
+    from scripts import workspace_state
+
+    root: Path = staging_workspace["root"]
+    repo_name: str = staging_workspace["repo_name"]
+    collection: str = staging_workspace["collection"]
+    repo_ws: Path = staging_workspace["repo_ws"]
+
+    _seed_repo_state(
+        workspace_state_module=workspace_state,
+        repo_ws=repo_ws,
+        repo_name=repo_name,
+        collection=collection,
+    )
+
+    calls = []
+
+    def fake_get_graph_collection_name(base_collection: str) -> str:
+        return f"{base_collection}_graph"
+
+    def fake_copy_collection_qdrant(**kwargs):
+        calls.append(("copy", kwargs.get("source"), kwargs.get("target")))
+        return kwargs.get("target")
+
+    monkeypatch.setattr(
+        indexing_admin,
+        "collection_mapping_index",
+        lambda *, work_dir: {collection: [{"repo_name": repo_name, "container_path": str(repo_ws)}]},
+    )
+    monkeypatch.setattr(indexing_admin, "_get_collection_point_count", lambda **_: 0)
+    monkeypatch.setattr(indexing_admin, "get_graph_collection_name", fake_get_graph_collection_name)
+    monkeypatch.setattr(indexing_admin, "copy_collection_qdrant", fake_copy_collection_qdrant)
+    monkeypatch.setattr(indexing_admin, "_wait_for_clone_points", lambda **_: None)
+    monkeypatch.setattr(indexing_admin, "_normalize_cloned_collection_schema", lambda **_: None)
+    monkeypatch.setattr(indexing_admin, "recreate_collection_qdrant", lambda **_: None)
+    monkeypatch.setattr(indexing_admin, "spawn_ingest_code", lambda **_: None)
+
+    indexing_admin.start_staging_rebuild(collection=collection, work_dir=str(root))
+
+    # Verify copy_collection_qdrant called for both main and graph collections
+    copy_calls = [c for c in calls if c[0] == "copy"]
+    assert len(copy_calls) >= 2, "Expected copy calls for both main and graph collections"
+
+    main_copy = next((c for c in copy_calls if c[1] == collection), None)
+    assert main_copy is not None, "Expected main collection to be copied"
+    assert main_copy[2] == f"{collection}_old"
+
+    graph_copy = next((c for c in copy_calls if c[1] == f"{collection}_graph"), None)
+    assert graph_copy is not None, "Expected graph collection to be copied"
+    assert graph_copy[2] == f"{collection}_old_graph"
+
+
+def test_staging_abort_deletes_graph_collection(staging_workspace: dict, monkeypatch: pytest.MonkeyPatch):
+    """Test that graph collection is deleted during abort."""
+    from scripts import indexing_admin
+    from scripts import workspace_state
+
+    root: Path = staging_workspace["root"]
+    repo_name: str = staging_workspace["repo_name"]
+    collection: str = staging_workspace["collection"]
+    repo_ws: Path = staging_workspace["repo_ws"]
+
+    _seed_repo_state(
+        workspace_state_module=workspace_state,
+        repo_ws=repo_ws,
+        repo_name=repo_name,
+        collection=collection,
+    )
+
+    delete_calls = []
+
+    def fake_get_graph_collection_name(base_collection: str) -> str:
+        return f"{base_collection}_graph"
+
+    def fake_delete_collection_qdrant(**kwargs):
+        delete_calls.append(kwargs.get("collection"))
+
+    monkeypatch.setattr(
+        indexing_admin,
+        "collection_mapping_index",
+        lambda *, work_dir: {collection: [{"repo_name": repo_name, "container_path": str(repo_ws)}]},
+    )
+    monkeypatch.setattr(indexing_admin, "_get_collection_point_count", lambda **_: 0)
+    monkeypatch.setattr(indexing_admin, "get_graph_collection_name", fake_get_graph_collection_name)
+    monkeypatch.setattr(indexing_admin, "copy_collection_qdrant", lambda **_: None)
+    monkeypatch.setattr(indexing_admin, "_wait_for_clone_points", lambda **_: None)
+    monkeypatch.setattr(indexing_admin, "_normalize_cloned_collection_schema", lambda **_: None)
+    monkeypatch.setattr(indexing_admin, "recreate_collection_qdrant", lambda **_: None)
+    monkeypatch.setattr(indexing_admin, "spawn_ingest_code", lambda **_: None)
+    monkeypatch.setattr(indexing_admin, "delete_collection_qdrant", fake_delete_collection_qdrant)
+
+    # Start staging to create _old artifacts
+    indexing_admin.start_staging_rebuild(collection=collection, work_dir=str(root))
+
+    # Abort staging
+    indexing_admin.abort_staging_rebuild(collection=collection, work_dir=str(root), delete_collection=True)
+
+    # Verify delete_collection_qdrant called for both main and graph collections
+    assert f"{collection}_old" in delete_calls, "Expected main _old collection to be deleted"
+    assert f"{collection}_old_graph" in delete_calls, "Expected graph _old collection to be deleted"
+
+
+def test_staging_activate_deletes_graph_collection(staging_workspace: dict, monkeypatch: pytest.MonkeyPatch):
+    """Test that graph collection is deleted during activate."""
+    from scripts import indexing_admin
+    from scripts import workspace_state
+
+    root: Path = staging_workspace["root"]
+    repo_name: str = staging_workspace["repo_name"]
+    collection: str = staging_workspace["collection"]
+    repo_ws: Path = staging_workspace["repo_ws"]
+
+    _seed_repo_state(
+        workspace_state_module=workspace_state,
+        repo_ws=repo_ws,
+        repo_name=repo_name,
+        collection=collection,
+    )
+
+    delete_calls = []
+
+    def fake_get_graph_collection_name(base_collection: str) -> str:
+        return f"{base_collection}_graph"
+
+    def fake_delete_collection_qdrant(**kwargs):
+        delete_calls.append(kwargs.get("collection"))
+
+    monkeypatch.setattr(
+        indexing_admin,
+        "collection_mapping_index",
+        lambda *, work_dir: {collection: [{"repo_name": repo_name, "container_path": str(repo_ws)}]},
+    )
+    monkeypatch.setattr(indexing_admin, "_get_collection_point_count", lambda **_: 0)
+    monkeypatch.setattr(indexing_admin, "get_graph_collection_name", fake_get_graph_collection_name)
+    monkeypatch.setattr(indexing_admin, "copy_collection_qdrant", lambda **_: None)
+    monkeypatch.setattr(indexing_admin, "_wait_for_clone_points", lambda **_: None)
+    monkeypatch.setattr(indexing_admin, "_normalize_cloned_collection_schema", lambda **_: None)
+    monkeypatch.setattr(indexing_admin, "recreate_collection_qdrant", lambda **_: None)
+    monkeypatch.setattr(indexing_admin, "spawn_ingest_code", lambda **_: None)
+    monkeypatch.setattr(indexing_admin, "delete_collection_qdrant", fake_delete_collection_qdrant)
+
+    # Start staging to create _old artifacts
+    indexing_admin.start_staging_rebuild(collection=collection, work_dir=str(root))
+
+    # Activate staging
+    indexing_admin.activate_staging_rebuild(collection=collection, work_dir=str(root))
+
+    # Verify delete_collection_qdrant called for both main and graph collections
+    assert f"{collection}_old" in delete_calls, "Expected main _old collection to be deleted"
+    assert f"{collection}_old_graph" in delete_calls, "Expected graph _old collection to be deleted"

--- a/tests/test_staging_lifecycle.py
+++ b/tests/test_staging_lifecycle.py
@@ -151,7 +151,7 @@ def test_staging_start_promote_activate_and_abort_are_consistent(
     def fake_normalize_cloned_collection_schema(**kwargs):
         calls["normalize_schema"] += 1
 
-    monkeypatch.setattr(indexing_admin, "get_graph_collection_name", fake_get_graph_collection_name)
+    monkeypatch.setattr(indexing_admin, "get_graph_collection_name_t", fake_get_graph_collection_name)
     monkeypatch.setattr(indexing_admin, "copy_collection_qdrant", fake_copy_collection_qdrant)
     monkeypatch.setattr(indexing_admin, "recreate_collection_qdrant", fake_recreate_collection_qdrant)
     monkeypatch.setattr(indexing_admin, "spawn_ingest_code", fake_spawn_ingest_code)
@@ -849,7 +849,7 @@ def test_staging_start_copies_graph_collection(staging_workspace: dict, monkeypa
         lambda *, work_dir: {collection: [{"repo_name": repo_name, "container_path": str(repo_ws)}]},
     )
     monkeypatch.setattr(indexing_admin, "_get_collection_point_count", lambda **_: 0)
-    monkeypatch.setattr(indexing_admin, "get_graph_collection_name", fake_get_graph_collection_name)
+    monkeypatch.setattr(indexing_admin, "get_graph_collection_name_t", fake_get_graph_collection_name)
     monkeypatch.setattr(indexing_admin, "copy_collection_qdrant", fake_copy_collection_qdrant)
     monkeypatch.setattr(indexing_admin, "_wait_for_clone_points", lambda **_: None)
     monkeypatch.setattr(indexing_admin, "_normalize_cloned_collection_schema", lambda **_: None)
@@ -902,7 +902,7 @@ def test_staging_abort_deletes_graph_collection(staging_workspace: dict, monkeyp
         lambda *, work_dir: {collection: [{"repo_name": repo_name, "container_path": str(repo_ws)}]},
     )
     monkeypatch.setattr(indexing_admin, "_get_collection_point_count", lambda **_: 0)
-    monkeypatch.setattr(indexing_admin, "get_graph_collection_name", fake_get_graph_collection_name)
+    monkeypatch.setattr(indexing_admin, "get_graph_collection_name_t", fake_get_graph_collection_name)
     monkeypatch.setattr(indexing_admin, "copy_collection_qdrant", lambda **_: None)
     monkeypatch.setattr(indexing_admin, "_wait_for_clone_points", lambda **_: None)
     monkeypatch.setattr(indexing_admin, "_normalize_cloned_collection_schema", lambda **_: None)
@@ -952,7 +952,7 @@ def test_staging_activate_deletes_graph_collection(staging_workspace: dict, monk
         lambda *, work_dir: {collection: [{"repo_name": repo_name, "container_path": str(repo_ws)}]},
     )
     monkeypatch.setattr(indexing_admin, "_get_collection_point_count", lambda **_: 0)
-    monkeypatch.setattr(indexing_admin, "get_graph_collection_name", fake_get_graph_collection_name)
+    monkeypatch.setattr(indexing_admin, "get_graph_collection_name_t", fake_get_graph_collection_name)
     monkeypatch.setattr(indexing_admin, "copy_collection_qdrant", lambda **_: None)
     monkeypatch.setattr(indexing_admin, "_wait_for_clone_points", lambda **_: None)
     monkeypatch.setattr(indexing_admin, "_normalize_cloned_collection_schema", lambda **_: None)

--- a/tests/test_workspace_state.py
+++ b/tests/test_workspace_state.py
@@ -433,3 +433,64 @@ class TestConstants:
         assert "" in ws_module.PLACEHOLDER_COLLECTION_NAMES
         assert "default-collection" in ws_module.PLACEHOLDER_COLLECTION_NAMES
         assert "my-collection" in ws_module.PLACEHOLDER_COLLECTION_NAMES
+
+
+# ============================================================================
+# Tests: Config Drift
+# ============================================================================
+class TestConfigDrift:
+    """Tests for indexing config drift detection."""
+
+    def test_get_indexing_config_snapshot_includes_graph_edges(self, ws_module, monkeypatch):
+        """Verify index_graph_edges key exists in snapshot with default value True."""
+        # Clear any existing env vars to test defaults
+        monkeypatch.delenv("INDEX_GRAPH_EDGES", raising=False)
+
+        snapshot = ws_module.get_indexing_config_snapshot()
+
+        assert "index_graph_edges" in snapshot, "index_graph_edges should be in config snapshot"
+        assert snapshot["index_graph_edges"] is True, "Default value for index_graph_edges should be True"
+
+    def test_get_indexing_config_snapshot_respects_env_var(self, ws_module, monkeypatch):
+        """Verify INDEX_GRAPH_EDGES env var is respected in snapshot."""
+        # Test with False
+        monkeypatch.setenv("INDEX_GRAPH_EDGES", "0")
+        snapshot = ws_module.get_indexing_config_snapshot()
+        assert snapshot["index_graph_edges"] is False, "INDEX_GRAPH_EDGES=0 should set index_graph_edges to False"
+
+        # Test with True
+        monkeypatch.setenv("INDEX_GRAPH_EDGES", "1")
+        snapshot = ws_module.get_indexing_config_snapshot()
+        assert snapshot["index_graph_edges"] is True, "INDEX_GRAPH_EDGES=1 should set index_graph_edges to True"
+
+    def test_config_drift_classifies_graph_edges_as_recreate(self, ws_module):
+        """Verify that changing INDEX_GRAPH_EDGES triggers recreate drift."""
+        from scripts import indexing_admin
+
+        # Verify the drift rule exists and is classified as "recreate"
+        assert "index_graph_edges" in indexing_admin.CONFIG_DRIFT_RULES, \
+            "index_graph_edges should be in CONFIG_DRIFT_RULES"
+        assert indexing_admin.CONFIG_DRIFT_RULES["index_graph_edges"] == "recreate", \
+            "index_graph_edges drift should be classified as 'recreate'"
+
+    def test_config_drift_graph_edges_true_to_false(self, ws_module):
+        """Verify drift from True->False is classified as recreate."""
+        from scripts import indexing_admin
+
+        old_config = {"index_graph_edges": True}
+        new_config = {"index_graph_edges": False}
+
+        # The actual drift detection is more complex, but we can verify the rule
+        rule = indexing_admin.CONFIG_DRIFT_RULES.get("index_graph_edges")
+        assert rule == "recreate", "Changing index_graph_edges should require recreate"
+
+    def test_config_drift_graph_edges_false_to_true(self, ws_module):
+        """Verify drift from False->True is classified as recreate."""
+        from scripts import indexing_admin
+
+        old_config = {"index_graph_edges": False}
+        new_config = {"index_graph_edges": True}
+
+        # The actual drift detection is more complex, but we can verify the rule
+        rule = indexing_admin.CONFIG_DRIFT_RULES.get("index_graph_edges")
+        assert rule == "recreate", "Changing index_graph_edges should require recreate"


### PR DESCRIPTION
admin:  Add graph collection lifecycle support and improve admin logging                                                                     

- Add INDEX_GRAPH_EDGES to CONFIG_DRIFT_RULES and documentation                                                         
- Extend delete_collection_everywhere to delete both main and graph collections
- Add _delete_collection_and_graph helper for staging cleanup
 - Replace print statements with proper logging throughout admin scripts
- Add flash message support to admin UI templates
- Extend test coverage for collection deletion with graph collections                                                    
- Add staging lifecycle and workspace state tests