### PR TITLE
Fix duplicate mapping keys in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -485,9 +485,6 @@ services:
     volumes:
       - workspace_pvc:/work:rw
       - codebase_pvc:/work/.codebase:rw
-    entrypoint: [ "sh", "-c", "mkdir -p /tmp/logs /tmp/huggingface/hub /tmp/huggingface/transformers /tmp/huggingface/fastembed && /app/scripts/wait-for-qdrant.sh && cd /app && python /app/scripts/ingest_code.py --root /work" ]
-    restart: "no" # Run once on startup, do not restart after completion
-    cpus: 2.0
     entrypoint: ["sh", "-c", "mkdir -p /tmp/logs /tmp/huggingface/hub /tmp/huggingface/transformers /tmp/huggingface/fastembed && /app/scripts/wait-for-qdrant.sh && cd /app && python /app/scripts/ingest_code.py --root /work"]
     restart: "no"  # Run once on startup, do not restart after completion
     cpus: 4.0


### PR DESCRIPTION
This PR fixes the duplicate mapping key errors in docker-compose.yml introduced in commit ddd1ceee8a48edf3b79c94247e49488cb2b2207e.

## Changes
- Removed duplicate definitions of `entrypoint`, `restart`, and `cpus` keys at lines 491-493
- Kept the second set of values (cpus: 4.0) as they appear to be the intended configuration

## Errors Fixed
```
line 491: mapping key "entrypoint" already defined at line 488
line 492: mapping key "restart" already defined at line 489
line 493: mapping key "cpus" already defined at line 490
```

The docker-compose file now validates successfully with `docker compose config`.