### PR TITLE
feat: replace beta signup CTA with GA-ready language

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -283,7 +283,7 @@
 					disabled={heroLoading}
 				/>
 				<button type="submit" class="btn btn-primary btn-lg" disabled={heroLoading}>
-					{heroLoading ? 'Sending…' : 'Join Open Beta'}
+					{heroLoading ? 'Sending…' : 'Get Started'}
 				</button>
 			</form>
 			{#if heroError}


### PR DESCRIPTION
Change hero button from "Join Open Beta" to "Get Started" as the product moves from beta to general availability.